### PR TITLE
feat(ha-dashboards): HA → Grafana observability pipeline with 5 story dashboards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ configs/teleport/data
 data
 .DS_Store
 .claude/
+.worktrees/

--- a/docs/superpowers/plans/2026-06-04-alloy-and-dashboards.md
+++ b/docs/superpowers/plans/2026-06-04-alloy-and-dashboards.md
@@ -1,0 +1,732 @@
+# Alloy Pi + Observability Dashboards Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Grafana Alloy on the Pi to ship Pi Docker and K3s pod logs to Loki, then add four Grafana dashboards covering personal analytics (AI/automation, home/music, storage/reading) and security (HA login attempts).
+
+**Architecture:** Alloy runs as a Docker container on the Pi, mounting the Docker socket for container logs and `/var/log/pods` for K3s pod logs. It pushes to local Loki (NodePort 30100) and Prometheus (NodePort 30090). Dashboards are Grafana JSON files provisioned via the existing `modules/prometheus-stack/dashboards/` Terraform pattern.
+
+**Tech Stack:** Grafana Alloy v1.8.2, Terraform kreuzwerker/docker provider (SSH remote), River config language, LogQL (Loki), PromQL (Prometheus)
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `modules/grafana-alloy-pi/main.tf` | Create | Docker container resource for Alloy on Pi |
+| `modules/grafana-alloy-pi/alloy.river` | Create | Pi-side Alloy pipeline: Docker logs, K3s pod logs, system metrics |
+| `modules/grafana-alloy-pi/variables.tf` | Create | Input variables |
+| `modules/grafana-alloy-pi/outputs.tf` | Create | Alloy UI URL |
+| `modules/grafana-alloy-pi/versions.tf` | Create | Docker provider constraint |
+| `main.tf` | Modify | Wire module |
+| `variables.tf` | Modify | Add alloy_pi_version variable |
+| `modules/prometheus-stack/dashboards/ai-automation.json` | Create | AI & Automation analytics dashboard |
+| `modules/prometheus-stack/dashboards/home-music.json` | Create | Home & Music analytics dashboard |
+| `modules/prometheus-stack/dashboards/ha-security.json` | Create | HA failed login attempts security dashboard |
+
+---
+
+## Task 1: Create grafana-alloy-pi module
+
+**Files:**
+- Create: `modules/grafana-alloy-pi/versions.tf`
+- Create: `modules/grafana-alloy-pi/variables.tf`
+- Create: `modules/grafana-alloy-pi/outputs.tf`
+- Create: `modules/grafana-alloy-pi/main.tf`
+- Create: `modules/grafana-alloy-pi/alloy.river`
+
+- [ ] **Step 1: Create versions.tf**
+
+```hcl
+# modules/grafana-alloy-pi/versions.tf
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Create variables.tf**
+
+```hcl
+# modules/grafana-alloy-pi/variables.tf
+variable "project_name" {
+  type    = string
+  default = "homelab"
+}
+
+variable "image_version" {
+  description = "Grafana Alloy Docker image version"
+  type        = string
+  default     = "v1.8.2"
+}
+
+variable "prometheus_url" {
+  description = "Local Prometheus remote_write endpoint (NodePort on Pi)"
+  type        = string
+  default     = "http://192.168.0.128:30090/api/v1/write"
+}
+
+variable "loki_url" {
+  description = "Local Loki push endpoint (NodePort on Pi)"
+  type        = string
+  default     = "http://192.168.0.128:30100/loki/api/v1/push"
+}
+
+variable "log_opts" {
+  type = map(string)
+  default = {
+    "max-size" = "10m"
+    "max-file" = "3"
+  }
+}
+```
+
+- [ ] **Step 3: Create outputs.tf**
+
+```hcl
+# modules/grafana-alloy-pi/outputs.tf
+output "ui_url" {
+  description = "Grafana Alloy debug UI (accessible on Pi LAN)"
+  value       = "http://192.168.0.128:12346"
+}
+```
+
+- [ ] **Step 4: Create main.tf**
+
+Note: This module uses the Pi's Docker provider (SSH remote), matching the pattern used by other Pi Docker modules like `modules/pi-hole/main.tf`.
+
+```hcl
+# modules/grafana-alloy-pi/main.tf
+resource "docker_image" "alloy" {
+  name         = "grafana/alloy:${var.image_version}"
+  keep_locally = true
+}
+
+resource "docker_container" "alloy" {
+  name  = "${var.project_name}-alloy-pi"
+  image = docker_image.alloy.image_id
+
+  restart = "unless-stopped"
+
+  command = [
+    "run",
+    "--server.http.listen-addr=0.0.0.0:12345",
+    "--storage.path=/var/lib/alloy",
+    "/etc/alloy/alloy.river",
+  ]
+
+  env = [
+    "PROMETHEUS_REMOTE_WRITE_URL=${var.prometheus_url}",
+    "LOKI_PUSH_URL=${var.loki_url}",
+  ]
+
+  volumes {
+    host_path      = "/opt/homelab/alloy/alloy.river"
+    container_path = "/etc/alloy/alloy.river"
+    read_only      = true
+  }
+
+  volumes {
+    host_path      = "/var/run/docker.sock"
+    container_path = "/var/run/docker.sock"
+    read_only      = true
+  }
+
+  volumes {
+    host_path      = "/var/log/pods"
+    container_path = "/var/log/pods"
+    read_only      = true
+  }
+
+  ports {
+    internal = 12345
+    external = 12346
+    protocol = "tcp"
+  }
+
+  memory = 192
+
+  log_driver = "json-file"
+  log_opts   = var.log_opts
+
+  healthcheck {
+    test         = ["CMD", "wget", "-qO-", "http://localhost:12345/-/healthy"]
+    interval     = "30s"
+    timeout      = "10s"
+    retries      = 3
+    start_period = "30s"
+  }
+}
+```
+
+Note: Port 12346 on the Pi (not 12345) to avoid conflict if Mac Mini Alloy is ever accessed via tunnel. The alloy.river is provisioned to `/opt/homelab/alloy/alloy.river` on the Pi via a `null_resource` (see Task 2).
+
+- [ ] **Step 5: Create alloy.river**
+
+```river
+// modules/grafana-alloy-pi/alloy.river
+
+// ─── Prometheus: Pi system metrics ──────────────────────────────────────────
+
+prometheus.exporter.unix "pi" {}
+
+prometheus.scrape "unix" {
+  targets         = prometheus.exporter.unix.pi.targets
+  forward_to      = [prometheus.remote_write.local.receiver]
+  scrape_interval = "30s"
+  job_name        = "pi-node-alloy"
+}
+
+prometheus.remote_write "local" {
+  endpoint {
+    url = env("PROMETHEUS_REMOTE_WRITE_URL")
+
+    queue_config {
+      max_samples_per_send = 1000
+      batch_send_deadline  = "5s"
+    }
+  }
+}
+
+// ─── Loki: Pi Docker container logs (HA, MA, Homebridge, Pi-hole) ───────────
+
+discovery.docker "running" {
+  host = "unix:///var/run/docker.sock"
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.docker.running.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+// ─── Loki: K3s pod logs (Prometheus, Loki, Grafana, Alertmanager) ───────────
+
+local.file_match "k3s_pods" {
+  path_targets = [{
+    __path__ = "/var/log/pods/**/*.log"
+    job      = "k3s-pods"
+  }]
+}
+
+loki.source.file "k3s_pods" {
+  targets    = local.file_match.k3s_pods.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+// ─── Loki: Push to local Loki ────────────────────────────────────────────────
+
+loki.write "local" {
+  endpoint {
+    url = env("LOKI_PUSH_URL")
+  }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add modules/grafana-alloy-pi/
+git commit -m "feat: add grafana-alloy-pi module for Pi log and metric collection"
+```
+
+---
+
+## Task 2: Provision alloy.river to Pi and wire module
+
+**Files:**
+- Modify: `main.tf`
+- Modify: `variables.tf`
+
+The Pi Docker provider is SSH-based. The alloy.river config must be copied to the Pi before the container starts. Look at how `modules/pi-hole/main.tf` handles SSH file provisioning — use the same `null_resource` + `connection` pattern.
+
+- [ ] **Step 1: Add variable to variables.tf**
+
+```hcl
+variable "alloy_pi_version" {
+  description = "Grafana Alloy version for Pi deployment"
+  type        = string
+  default     = "v1.8.2"
+}
+```
+
+- [ ] **Step 2: Add provisioner + module to main.tf**
+
+```hcl
+# Copy alloy.river to Pi before container starts
+resource "null_resource" "alloy_pi_config" {
+  triggers = {
+    config_hash = filemd5("${path.module}/modules/grafana-alloy-pi/alloy.river")
+  }
+
+  connection {
+    type        = "ssh"
+    host        = var.raspberry_pi_ip
+    user        = var.raspberry_pi_user
+    private_key = file("~/.ssh/id_ed25519")
+    port        = var.raspberry_pi_ssh_port
+  }
+
+  provisioner "remote-exec" {
+    inline = ["mkdir -p /opt/homelab/alloy"]
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/modules/grafana-alloy-pi/alloy.river"
+    destination = "/opt/homelab/alloy/alloy.river"
+  }
+}
+
+module "grafana_alloy_pi" {
+  source     = "./modules/grafana-alloy-pi"
+  depends_on = [null_resource.alloy_pi_config]
+
+  providers = {
+    docker = docker.pi
+  }
+
+  project_name   = var.project_name
+  image_version  = var.alloy_pi_version
+  prometheus_url = "http://${var.raspberry_pi_ip}:30090/api/v1/write"
+  loki_url       = "http://${var.raspberry_pi_ip}:30100/loki/api/v1/push"
+  log_opts       = {}
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add main.tf variables.tf
+git commit -m "feat: wire grafana-alloy-pi into root config with SSH provisioner"
+```
+
+---
+
+## Task 3: Deploy Pi Alloy and verify
+
+- [ ] **Step 1: Plan**
+
+```bash
+terraform plan
+```
+
+Expected: `1 null_resource` + `1 docker_image` + `1 docker_container` to add
+
+- [ ] **Step 2: Apply**
+
+```bash
+terraform apply
+```
+
+- [ ] **Step 3: Verify Alloy healthy on Pi**
+
+```bash
+ssh rainforest@192.168.0.128 "curl -s http://localhost:12346/-/healthy"
+```
+
+Expected: `Alloy is Healthy.`
+
+- [ ] **Step 4: Verify Pi Docker logs in Loki**
+
+Open Grafana at `http://192.168.0.128:30080`. Explore → Loki:
+
+```logql
+{job="docker", container="homeassistant"} | limit 20
+```
+
+Expected: Home Assistant log lines
+
+- [ ] **Step 5: Verify K3s pod logs in Loki**
+
+```logql
+{job="k3s-pods"} | limit 20
+```
+
+Expected: log lines from Prometheus/Loki/Grafana pods on the Pi
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit --allow-empty -m "chore: alloy pi deployment verified"
+```
+
+---
+
+## Task 4: AI & Automation dashboard
+
+**Files:**
+- Create: `modules/prometheus-stack/dashboards/ai-automation.json`
+
+This dashboard uses Loki log-count queries (no custom Prometheus metrics needed — cAdvisor provides resource usage, Loki counts log events as a proxy for activity).
+
+- [ ] **Step 1: Create ai-automation.json**
+
+```json
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "title": "n8n Workflows",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "n8n Executions (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))", "legendFormat": "executions", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "n8n Errors (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))", "legendFormat": "errors", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 1},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "n8n Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "id": 5,
+      "title": "Whisper STT",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 8},
+      "id": 6,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Transcription Requests (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homelab-whisper\"} |= \"transcription\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 8},
+      "id": 7,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Whisper Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container=\"homelab-whisper\"}", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "id": 8,
+      "title": "Open WebUI & Flowise",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 15},
+      "id": 9,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Open WebUI Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 15},
+      "id": 10,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Flowise Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "analytics", "ai"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "AI & Automation",
+  "uid": "homelab-ai-automation",
+  "version": 1
+}
+```
+
+Note: `${loki_uid}` will be replaced by the Terraform template with the actual Loki datasource UID. Check how existing dashboards handle this in `modules/prometheus-stack/main.tf` — look for `templatefile` or `replace` calls on the JSON.
+
+- [ ] **Step 2: Verify the JSON is valid**
+
+```bash
+python3 -c "import json; json.load(open('modules/prometheus-stack/dashboards/ai-automation.json'))" && echo "Valid JSON"
+```
+
+Expected: `Valid JSON`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modules/prometheus-stack/dashboards/ai-automation.json
+git commit -m "feat: add AI & Automation Grafana dashboard"
+```
+
+---
+
+## Task 5: Home & Music dashboard
+
+**Files:**
+- Create: `modules/prometheus-stack/dashboards/home-music.json`
+
+- [ ] **Step 1: Create home-music.json**
+
+```json
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Home Assistant",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Automations Fired (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homeassistant\"} |= \"Executing script\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "HA Errors (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homeassistant\"} |= \"ERROR\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "HA Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container=\"homeassistant\"} | level != \"debug\"", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
+      "id": 5,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Google Home Commands",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container=\"homeassistant\"} |= \"google_assistant\"", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11},
+      "id": 6,
+      "title": "Music Assistant",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 12},
+      "id": 7,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Tracks Played (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"music-assistant-server\"} |= \"Playing\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 12},
+      "id": 8,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Music Assistant Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container=\"music-assistant-server\"}", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "analytics", "home"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "Home & Music",
+  "uid": "homelab-home-music",
+  "version": 1
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+```bash
+python3 -c "import json; json.load(open('modules/prometheus-stack/dashboards/home-music.json'))" && echo "Valid JSON"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modules/prometheus-stack/dashboards/home-music.json
+git commit -m "feat: add Home & Music Grafana dashboard"
+```
+
+---
+
+## Task 6: HA Security dashboard
+
+**Files:**
+- Create: `modules/prometheus-stack/dashboards/ha-security.json`
+
+- [ ] **Step 1: Create ha-security.json**
+
+```json
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 5}, {"color": "red", "value": 20}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Failed Login Attempts (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homeassistant\"} |= \"invalid authentication\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Banned IPs (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homeassistant\"} |= \"ban\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"custom": {"fillOpacity": 10}, "color": {"mode": "palette-classic"}}},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"tooltip": {"mode": "single"}},
+      "title": "Failed Login Attempts Over Time",
+      "type": "timeseries",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container=\"homeassistant\"} |= \"invalid authentication\" [5m]))", "legendFormat": "failed logins", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "HA Authentication Log (failed attempts)",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container=\"homeassistant\"} |= \"invalid authentication\"", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "security"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "HA Security",
+  "uid": "homelab-ha-security",
+  "version": 1
+}
+```
+
+- [ ] **Step 2: Validate JSON**
+
+```bash
+python3 -c "import json; json.load(open('modules/prometheus-stack/dashboards/ha-security.json'))" && echo "Valid JSON"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add modules/prometheus-stack/dashboards/ha-security.json
+git commit -m "feat: add HA Security Grafana dashboard"
+```
+
+---
+
+## Task 7: Wire dashboards into Terraform and deploy
+
+- [ ] **Step 1: Check how existing dashboards are provisioned in prometheus-stack**
+
+```bash
+grep -n "dashboard\|ConfigMap\|grafana" modules/prometheus-stack/main.tf | head -30
+```
+
+Find the `kubernetes_config_map` resource that provisions dashboards and add the three new JSON files to it, following the exact same pattern as existing entries.
+
+- [ ] **Step 2: Apply**
+
+```bash
+terraform apply
+```
+
+- [ ] **Step 3: Verify dashboards appear in Grafana**
+
+Open `http://192.168.0.128:30080`. Go to **Dashboards**. Confirm these three appear:
+- AI & Automation
+- Home & Music
+- HA Security
+
+- [ ] **Step 4: Spot-check one panel**
+
+Open **HA Security** dashboard. The "Failed Login Attempts (24h)" stat panel should show a number > 0 (we saw many failed attempts from Taiwan IPs in the logs).
+
+If it shows 0, open **Explore → Loki** and run:
+```logql
+{container="homeassistant"} |= "invalid authentication" | limit 5
+```
+If that returns results, the LogQL query in the dashboard may need tuning (the container label might differ — check the actual label with `{job="docker"} | limit 1`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/prometheus-stack/main.tf
+git commit -m "feat: provision AI/Automation, Home/Music, HA Security dashboards in Grafana"
+```

--- a/docs/superpowers/specs/2026-06-04-homelab-observability-design.md
+++ b/docs/superpowers/specs/2026-06-04-homelab-observability-design.md
@@ -1,0 +1,110 @@
+# Homelab Observability & Service Value Design
+
+**Date:** 2026-06-04
+**Status:** Approved
+**Repos:** rainforest-iot, rainforest-homelab
+
+## Goal
+
+Full observability across all homelab services — both operational health and personal analytics — using the existing Prometheus + Loki + Grafana stack on the Pi, extended by Grafana Alloy agents on each machine.
+
+## Architecture & Data Flow
+
+```
+Mac Mini                              Raspberry Pi 5
+──────────────────────────────        ──────────────────────────────────
+Alloy (Docker container)              Alloy (Docker container)
+  ├─ Docker containers:               ├─ Docker containers:
+  │   whisper, calibre-web,           │   homeassistant, music-assistant,
+  │   docker-mcp, flowise             │   homebridge, pihole
+  ├─ Kubernetes pods (via API):       ├─ K3s pods (via API):
+  │   open-webui, n8n, minio,         │   prometheus, loki, grafana,
+  │   pgadmin, flowise                │   alertmanager, node-exporter
+  ├─ node_exporter (Mac host)         ├─ node_exporter (Pi host)
+  └─ pushes → Loki + Prometheus       └─ pushes → Loki + Prometheus
+                                           (local, already deployed)
+                                                ↓
+                                           Grafana (K3s, port 30080)
+```
+
+- Loki and Prometheus already run on K3s on the Pi — Alloy feeds them from both machines
+- Alloy uses `loki.source.kubernetes` for K8s/K3s pod logs (structured, labelled by namespace/pod/container)
+- Alloy uses `loki.source.docker` for Docker container logs on both machines
+- No changes to existing Prometheus scrape configs, dashboards, or service deployments
+
+## Dashboards
+
+### Operational Health (expand existing)
+
+| Dashboard | Changes |
+|-----------|---------|
+| Homelab Overview | Expand with K8s pod restart counts, container health |
+| Kubernetes Cluster | Exists — no changes needed |
+| Network Health (Blackbox) | Exists — no changes needed |
+
+### Personal Analytics (new)
+
+| Dashboard | Key Panels |
+|-----------|-----------|
+| **AI & Automation** | Open WebUI: active sessions, models used; n8n: executions per workflow, success/fail rate; Flowise: flow runs; Whisper: request count, avg latency |
+| **Home & Music** | HA: automations fired, Google Home commands, devices online; Music Assistant: tracks played, active players |
+| **Storage & Reading** | MinIO: bucket sizes, request rates; Calibre Web: book downloads, active sessions |
+
+### Security Visibility (expand existing)
+
+| Dashboard | Changes |
+|-----------|---------|
+| CrowdSec Events | Exists — no changes needed |
+| Pi-hole Stats | Exists — no changes needed |
+| **HA Login Attempts** | New — failed auth by IP over time (sourced from HA logs in Loki) |
+| **Cloudflare Access** | New — Zero Trust auth events per service (sourced from Cloudflare Logpush → Loki, or deferred if Logpush setup is out of scope) |
+
+### Log Explorer
+
+Saved Loki queries per service group — pre-filtered by container/pod label. Allows jumping directly to any service's logs without writing LogQL manually.
+
+## Service Value Map
+
+| Service | Operational signals | Personal analytics |
+|---------|--------------------|--------------------|
+| Open WebUI | Pod restarts, error logs | Sessions, models used |
+| n8n | Pod restarts, error logs | Executions, success/fail rate |
+| Whisper STT | Container health, error logs | Request count, avg latency |
+| Flowise | Pod restarts, error logs | Flow run count |
+| Calibre Web | Container health | Book downloads, sessions |
+| MinIO | Pod restarts, storage usage | Bucket sizes, request rates |
+| pgAdmin | Pod restarts | (admin tool — health only) |
+| Home Assistant | Container health | Automations fired, Google Home commands |
+| Music Assistant | Container health | Tracks played, active players |
+| Pi-hole | Container health | Block rate, query volume (existing dashboard) |
+| CrowdSec | Exists | Banned IPs, alerts (existing dashboard) |
+| Homebridge | Container health | (bridge tool — health only) |
+
+## Security Services — What They Protect
+
+| Service | What it does for you |
+|---------|---------------------|
+| **CrowdSec** | Crowdsourced threat intel — bans IPs attempting brute force, scanning, or known malicious patterns. Blocks at the network level before requests reach your services |
+| **Pi-hole** | DNS-level ad/tracker blocking — prevents devices from phoning home to ad networks and blocks known malware domains. Block rate and top blocked domains visible in existing Grafana dashboard |
+| **Cloudflare Zero Trust** | Access gateway — every protected service requires email verification before reaching your homelab. Logs all auth attempts per service |
+| **Cloudflare Tunnel** | Hides your home IP entirely — no ports open on your router, no direct path to your network from the internet |
+| **HA failed auth monitoring** | Visibility into credential-stuffing attempts against Home Assistant (we saw IPs from Taiwan actively attempting logins) |
+
+## Implementation Scope
+
+### rainforest-iot repo
+- New module `modules/grafana-alloy-pi/` — Alloy on Pi (Docker + K3s logs + metrics)
+- New dashboards in `modules/prometheus-stack/dashboards/`: `ai-automation.json`, `home-music.json`, `storage-reading.json`, `ha-security.json`
+- Update `modules/monitoring-integrations/main.tf` — wire new Alloy scrape targets
+
+### rainforest-homelab repo
+- Complete `modules/grafana-alloy/` module (stub exists) — Alloy on Mac Mini (Docker + K8s logs + metrics)
+
+## Delivery Order
+
+Each step is independently useful:
+
+1. **Alloy on Mac Mini** → Mac Mini container + K8s pod logs flow into Loki
+2. **Alloy on Pi** → Pi Docker + K3s logs flow into Loki
+3. **Personal analytics dashboards** → AI, Home, Storage panels in Grafana
+4. **Security dashboards** → HA login attempts + Cloudflare access events

--- a/main.tf
+++ b/main.tf
@@ -419,3 +419,41 @@ module "velero" {
   minio_access_key = var.minio_access_key
   minio_secret_key = var.minio_secret_key
 }
+
+resource "null_resource" "alloy_pi_config" {
+  triggers = {
+    config_hash = filemd5("${path.module}/modules/grafana-alloy-pi/alloy.river")
+  }
+
+  connection {
+    type        = "ssh"
+    host        = var.raspberry_pi_ip
+    user        = var.raspberry_pi_user
+    private_key = file("~/.ssh/id_ed25519.rpi5")
+    port        = var.raspberry_pi_port
+  }
+
+  provisioner "remote-exec" {
+    inline = ["mkdir -p /opt/homelab/alloy"]
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/modules/grafana-alloy-pi/alloy.river"
+    destination = "/opt/homelab/alloy/alloy.river"
+  }
+}
+
+module "grafana_alloy_pi" {
+  source     = "./modules/grafana-alloy-pi"
+  depends_on = [null_resource.alloy_pi_config]
+
+  providers = {
+    docker = docker.raspberry-pi
+  }
+
+  project_name   = "homelab"
+  image_version  = var.alloy_pi_version
+  prometheus_url = "http://${var.raspberry_pi_ip}:30090/api/v1/write"
+  loki_url       = "http://${var.raspberry_pi_ip}:30100/loki/api/v1/push"
+  log_opts       = {}
+}

--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,7 @@ module "pi-hole" {
   ssh_user         = var.raspberry_pi_user
   ssh_port         = var.raspberry_pi_port
   exporter_version = var.pihole_exporter_version
-  pihole_api_token = var.pihole_api_token
+  pihole_password = var.pihole_password
 }
 
 # K3s Cluster configuration (when enabled)
@@ -260,7 +260,7 @@ module "monitoring_integrations" {
   mac_mini_ip              = var.mac_mini_ip
   mac_mini_docker_endpoint = var.mac_mini_docker_endpoint
   pihole_port              = var.pihole_web_port
-  pihole_api_token         = var.pihole_api_token
+  pihole_password         = var.pihole_password
   ntopng_port              = var.ntopng_web_port
 }
 
@@ -355,8 +355,11 @@ module "crowdsec" {
 
   project_name     = "homelab"
   crowdsec_version = var.crowdsec_version
-  bouncer_version  = var.crowdsec_bouncer_version
   bouncer_api_key  = var.crowdsec_bouncer_api_key
+  enable_bouncer   = var.crowdsec_bouncer_api_key != ""
+  hostname         = var.raspberry_pi_ip
+  ssh_user         = var.raspberry_pi_user
+  ssh_port         = var.raspberry_pi_port
   timezone         = var.timezone
   log_opts         = local.common_log_opts
 }

--- a/main.tf
+++ b/main.tf
@@ -429,12 +429,12 @@ resource "null_resource" "alloy_pi_config" {
     type        = "ssh"
     host        = var.raspberry_pi_ip
     user        = var.raspberry_pi_user
-    private_key = file("~/.ssh/id_ed25519.rpi5")
+    private_key = var.pi_ssh_private_key
     port        = var.raspberry_pi_port
   }
 
   provisioner "remote-exec" {
-    inline = ["mkdir -p /opt/homelab/alloy"]
+    inline = ["sudo mkdir -p /opt/homelab/alloy && sudo chown ${var.raspberry_pi_user}:${var.raspberry_pi_user} /opt/homelab/alloy"]
   }
 
   provisioner "file" {

--- a/main.tf
+++ b/main.tf
@@ -229,6 +229,9 @@ module "prometheus_stack" {
   external_ip           = var.raspberry_pi_ip
   blackbox_http_targets = var.blackbox_http_targets
   blackbox_icmp_targets = var.blackbox_icmp_targets
+
+  # Home Assistant Prometheus scraping — set token to enable the HA scrape job
+  homeassistant_token = var.homeassistant_token
 }
 
 # Wait for Prometheus CRDs to be available

--- a/modules/crowdsec/main.tf
+++ b/modules/crowdsec/main.tf
@@ -3,11 +3,8 @@ resource "docker_image" "crowdsec" {
   keep_locally = true
 }
 
-resource "docker_image" "bouncer" {
-  count        = var.enable_bouncer ? 1 : 0
-  name         = "crowdsecurity/firewall-bouncer-iptables:${var.bouncer_version}"
-  keep_locally = true
-}
+# Bouncer is installed natively via apt (not Docker) so it can modify host iptables.
+# Docker bouncers can only affect the container's network namespace.
 
 resource "docker_network" "crowdsec" {
   name = "${var.project_name}-crowdsec"
@@ -85,33 +82,49 @@ resource "docker_container" "crowdsec" {
   }
 }
 
-resource "docker_container" "crowdsec_bouncer" {
+# Install CrowdSec firewall bouncer natively via apt.
+# Runs as a systemd service on the Pi host with direct iptables access.
+# Triggers re-install if the API key changes.
+resource "null_resource" "crowdsec_bouncer" {
   count = var.enable_bouncer ? 1 : 0
-  name  = "${var.project_name}-crowdsec-bouncer"
-  image = docker_image.bouncer[0].image_id
 
-  restart = "unless-stopped"
-
-  capabilities {
-    add = ["NET_ADMIN", "NET_RAW"]
+  triggers = {
+    bouncer_api_key = var.bouncer_api_key
+    hostname        = var.hostname
+    ssh_port        = var.ssh_port
+    ssh_user        = var.ssh_user
   }
 
-  network_mode = "host"
-
-  env = [
-    "TZ=${var.timezone}",
-    "CROWDSEC_LAPI_URL=http://127.0.0.1:6081",
-    "CROWDSEC_LAPI_KEY=${var.bouncer_api_key}",
-    "GID=1000",
-  ]
-
-  memory = 64
-
-  # Docker sets memory_swap to 2× memory when unspecified, causing perpetual diff.
-  lifecycle {
-    ignore_changes = [memory_swap]
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-BASH
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} bash << 'ENDSSH'
+        set -e
+        # Add CrowdSec repo if not present
+        if ! dpkg -l crowdsec-firewall-bouncer-iptables &>/dev/null; then
+          curl -s https://packagecloud.io/install/repositories/crowdsec/crowdsec/script.deb.sh | sudo bash
+          sudo apt-get install -y crowdsec-firewall-bouncer-iptables
+        fi
+        # Configure the bouncer API key and LAPI URL
+        sudo sed -i "s|^api_key:.*|api_key: ${var.bouncer_api_key}|" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+        sudo sed -i "s|^api_url:.*|api_url: http://127.0.0.1:6081/|" /etc/crowdsec/bouncers/crowdsec-firewall-bouncer.yaml
+        sudo systemctl enable crowdsec-firewall-bouncer
+        sudo systemctl restart crowdsec-firewall-bouncer
+        sudo systemctl is-active crowdsec-firewall-bouncer
+ENDSSH
+    BASH
   }
 
-  log_driver = "json-file"
-  log_opts   = var.log_opts
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-BASH
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${self.triggers.ssh_port} ${self.triggers.ssh_user}@${self.triggers.hostname} \
+        "sudo systemctl stop crowdsec-firewall-bouncer || true && sudo apt-get remove -y crowdsec-firewall-bouncer-iptables || true"
+    BASH
+  }
+
+  depends_on = [docker_container.crowdsec]
 }

--- a/modules/crowdsec/variables.tf
+++ b/modules/crowdsec/variables.tf
@@ -23,9 +23,27 @@ variable "bouncer_api_key" {
 }
 
 variable "enable_bouncer" {
-  description = "Enable firewall bouncer container (requires Docker Hub auth for CrowdSec bouncer images)"
+  description = "Enable native iptables bouncer (installed via apt on the Pi host)"
   type        = bool
   default     = false
+}
+
+variable "hostname" {
+  description = "Hostname or IP of the Raspberry Pi for SSH bouncer install"
+  type        = string
+  default     = "raspberrypi-5.local"
+}
+
+variable "ssh_user" {
+  description = "SSH user for Raspberry Pi"
+  type        = string
+  default     = "rainforest"
+}
+
+variable "ssh_port" {
+  description = "SSH port for Raspberry Pi"
+  type        = number
+  default     = 22
 }
 
 variable "timezone" {

--- a/modules/grafana-alloy-pi/alloy.river
+++ b/modules/grafana-alloy-pi/alloy.river
@@ -1,0 +1,84 @@
+// ─── Prometheus: Pi system metrics ──────────────────────────────────────────
+
+prometheus.exporter.unix "pi" {}
+
+prometheus.scrape "unix" {
+  targets         = prometheus.exporter.unix.pi.targets
+  forward_to      = [prometheus.remote_write.local.receiver]
+  scrape_interval = "30s"
+  job_name        = "pi-node-alloy"
+}
+
+prometheus.remote_write "local" {
+  endpoint {
+    url = env("PROMETHEUS_REMOTE_WRITE_URL")
+
+    queue_config {
+      max_samples_per_send = 1000
+      batch_send_deadline  = "5s"
+    }
+  }
+}
+
+// ─── Loki: Pi Docker container logs ─────────────────────────────────────────
+
+discovery.docker "running" {
+  host = "unix:///var/run/docker.sock"
+}
+
+discovery.relabel "docker_labels" {
+  targets = discovery.docker.running.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container_name"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_id"]
+    target_label  = "container_id"
+  }
+
+  rule {
+    replacement  = "docker"
+    target_label = "job"
+  }
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.docker_labels.output
+  forward_to = [loki.process.drop_self.receiver]
+}
+
+loki.process "drop_self" {
+  forward_to = [loki.write.local.receiver]
+
+  stage.drop {
+    source = "container_name"
+    value  = "homelab-alloy-pi"
+  }
+}
+
+// ─── Loki: K3s pod logs ──────────────────────────────────────────────────────
+
+local.file_match "k3s_pods" {
+  path_targets = [{
+    __path__ = "/var/log/pods/**/*.log"
+    job      = "k3s-pods"
+  }]
+}
+
+loki.source.file "k3s_pods" {
+  targets    = local.file_match.k3s_pods.targets
+  forward_to = [loki.write.local.receiver]
+}
+
+// ─── Loki: Push to local Loki ────────────────────────────────────────────────
+
+loki.write "local" {
+  endpoint {
+    url = env("LOKI_PUSH_URL")
+  }
+}

--- a/modules/grafana-alloy-pi/alloy.river
+++ b/modules/grafana-alloy-pi/alloy.river
@@ -65,8 +65,8 @@ loki.process "drop_self" {
 
 local.file_match "k3s_pods" {
   path_targets = [{
-    __path__ = "/var/log/pods/**/*.log"
-    job      = "k3s-pods"
+    __path__ = "/var/log/pods/**/*.log",
+    job      = "k3s-pods",
   }]
 }
 

--- a/modules/grafana-alloy-pi/main.tf
+++ b/modules/grafana-alloy-pi/main.tf
@@ -1,0 +1,61 @@
+resource "docker_image" "alloy" {
+  name         = "grafana/alloy:${var.image_version}"
+  keep_locally = true
+}
+
+resource "docker_container" "alloy" {
+  name  = "${var.project_name}-alloy-pi"
+  image = docker_image.alloy.image_id
+
+  restart = "unless-stopped"
+
+  command = [
+    "run",
+    "--server.http.listen-addr=0.0.0.0:12345",
+    "--storage.path=/var/lib/alloy",
+    "/etc/alloy/alloy.river",
+  ]
+
+  env = [
+    "PROMETHEUS_REMOTE_WRITE_URL=${var.prometheus_url}",
+    "LOKI_PUSH_URL=${var.loki_url}",
+  ]
+
+  volumes {
+    host_path      = "/opt/homelab/alloy/alloy.river"
+    container_path = "/etc/alloy/alloy.river"
+    read_only      = true
+  }
+
+  volumes {
+    host_path      = "/var/run/docker.sock"
+    container_path = "/var/run/docker.sock"
+    read_only      = true
+  }
+
+  volumes {
+    host_path      = "/var/log/pods"
+    container_path = "/var/log/pods"
+    read_only      = true
+  }
+
+  ports {
+    internal = 12345
+    external = 12346
+    protocol = "tcp"
+  }
+
+  memory     = 192
+  cpu_shares = 512
+
+  log_driver = "json-file"
+  log_opts   = var.log_opts
+
+  healthcheck {
+    test         = ["CMD", "wget", "-qO-", "http://localhost:12345/-/healthy"]
+    interval     = "30s"
+    timeout      = "10s"
+    retries      = 3
+    start_period = "30s"
+  }
+}

--- a/modules/grafana-alloy-pi/outputs.tf
+++ b/modules/grafana-alloy-pi/outputs.tf
@@ -1,0 +1,4 @@
+output "ui_url" {
+  description = "Grafana Alloy debug UI (accessible on Pi LAN)"
+  value       = "http://192.168.0.128:12346"
+}

--- a/modules/grafana-alloy-pi/variables.tf
+++ b/modules/grafana-alloy-pi/variables.tf
@@ -1,0 +1,30 @@
+variable "project_name" {
+  type    = string
+  default = "homelab"
+}
+
+variable "image_version" {
+  description = "Grafana Alloy Docker image version"
+  type        = string
+  default     = "v1.8.2"
+}
+
+variable "prometheus_url" {
+  description = "Local Prometheus remote_write endpoint (NodePort on Pi)"
+  type        = string
+  default     = "http://192.168.0.128:30090/api/v1/write"
+}
+
+variable "loki_url" {
+  description = "Local Loki push endpoint (NodePort on Pi)"
+  type        = string
+  default     = "http://192.168.0.128:30100/loki/api/v1/push"
+}
+
+variable "log_opts" {
+  type = map(string)
+  default = {
+    "max-size" = "10m"
+    "max-file" = "3"
+  }
+}

--- a/modules/grafana-alloy-pi/versions.tf
+++ b/modules/grafana-alloy-pi/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/homeassistant/main.tf
+++ b/modules/homeassistant/main.tf
@@ -185,6 +185,39 @@ resource "null_resource" "ha_prometheus_config" {
   depends_on = [null_resource.ha_proxy_config]
 }
 
+# Inject a template sensor that exports the vacuum state as a numeric value.
+# HA's Prometheus integration skips the vacuum domain because its state is a
+# string (docked/cleaning/returning/…). A template sensor converts it to a
+# number so Prometheus can store it.
+#
+# State mapping:  0=unknown  1=cleaning  2=returning  3=docked  4=paused  5=idle  6=error
+resource "null_resource" "ha_vacuum_template_sensor" {
+  triggers = {
+    container_id = docker_container.homeassistant.id
+  }
+
+  provisioner "local-exec" {
+    command = <<-BASH
+      set -e
+      if ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+          -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} \
+          "docker exec homeassistant grep -q 'roborock_state_numeric' /config/configuration.yaml" 2>/dev/null; then
+        echo "HA vacuum template sensor already present, skipping"
+        exit 0
+      fi
+      BLOCK=$(printf '\ntemplate:\n  - sensor:\n      - name: "Roborock State Numeric"\n        unique_id: roborock_state_numeric\n        icon: mdi:robot-vacuum\n        state: >\n          {%% set s = states('"'"'vacuum.roborock_qrevo_c_pro'"'"') %%}\n          {%% if s == '"'"'cleaning'"'"' %%}1{%% elif s == '"'"'returning'"'"' %%}2{%% elif s == '"'"'docked'"'"' %%}3{%% elif s == '"'"'paused'"'"' %%}4{%% elif s == '"'"'idle'"'"' %%}5{%% elif s == '"'"'error'"'"' %%}6{%% else %%}0{%% endif %%}\n' | base64 | tr -d '\n')
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} \
+        "echo '$${BLOCK}' | base64 -d | docker exec --interactive homeassistant sh -c 'cat >> /config/configuration.yaml'"
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} docker restart homeassistant
+      echo "HA vacuum template sensor written, HA restarted"
+    BASH
+  }
+
+  depends_on = [null_resource.ha_prometheus_config]
+}
+
 # HACS (Home Assistant Community Store) installation
 resource "null_resource" "hacs_installation" {
   count = var.enable_hacs ? 1 : 0

--- a/modules/homeassistant/main.tf
+++ b/modules/homeassistant/main.tf
@@ -154,6 +154,37 @@ resource "null_resource" "ha_proxy_config" {
   }
 }
 
+resource "null_resource" "ha_prometheus_config" {
+  triggers = {
+    container_id = docker_container.homeassistant.id
+  }
+
+  provisioner "local-exec" {
+    command = <<-BASH
+      set -e
+      # Exit early if the prometheus: block is already present (config volume persists
+      # across container recreation, so this is the common path after a redeploy).
+      if ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+          -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} \
+          "docker exec homeassistant grep -q '^prometheus:' /config/configuration.yaml" 2>/dev/null; then
+        echo "HA prometheus config already present, skipping"
+        exit 0
+      fi
+      # Base64-encode the YAML block locally and decode+append inside the
+      # container — avoids all SSH/docker-exec quoting complexity.
+      BLOCK=$(printf '\nprometheus:\n' | base64 | tr -d '\n')
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} \
+        "echo '$${BLOCK}' | base64 -d | docker exec --interactive homeassistant sh -c 'cat >> /config/configuration.yaml'"
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} docker restart homeassistant
+      echo "HA prometheus config written, HA restarted"
+    BASH
+  }
+
+  depends_on = [null_resource.ha_trusted_proxy]
+}
+
 # HACS (Home Assistant Community Store) installation
 resource "null_resource" "hacs_installation" {
   count = var.enable_hacs ? 1 : 0

--- a/modules/homeassistant/main.tf
+++ b/modules/homeassistant/main.tf
@@ -182,7 +182,7 @@ resource "null_resource" "ha_prometheus_config" {
     BASH
   }
 
-  depends_on = [null_resource.ha_trusted_proxy]
+  depends_on = [null_resource.ha_proxy_config]
 }
 
 # HACS (Home Assistant Community Store) installation

--- a/modules/homepage/main.tf
+++ b/modules/homepage/main.tf
@@ -31,7 +31,7 @@ locals {
   # Normalize hostnames for allowed hosts logic
   # Use split to derive the short hostname robustly (works if input is short or FQDN)
   short_hostname = element(split(".", var.raspberry_pi_hostname), 0)
-  allowed_hosts  = "${local.short_hostname},${local.short_hostname}.local,${local.short_hostname}:${var.external_port},${local.short_hostname}.local:${var.external_port}"
+  allowed_hosts  = "${local.short_hostname},${local.short_hostname}.local,${local.short_hostname}:${var.external_port},${local.short_hostname}.local:${var.external_port},homepage.rainforest.tools"
 }
 
 # Ensure build directory exists

--- a/modules/homepage/templates/services.yaml.tpl
+++ b/modules/homepage/templates/services.yaml.tpl
@@ -51,11 +51,17 @@
 
 - "Raspberry Pi 5 (IoT Platform)":
     - HomeAssistant:
-        href: http://${raspberry_pi_hostname}:8123
+        href: https://homeassistant.rainforest.tools
         description: "Home Automation"
         icon: home-assistant.png
         server: pi5-docker
         container: homeassistant
+    - Music Assistant:
+        href: https://music-assistant.rainforest.tools
+        description: "Multi-Room Music Player"
+        icon: mdi-music
+        server: pi5-docker
+        container: music-assistant-server
     - Homebridge:
         href: http://${raspberry_pi_hostname}:8581
         description: "HomeKit Bridge"

--- a/modules/homepage/templates/services.yaml.tpl
+++ b/modules/homepage/templates/services.yaml.tpl
@@ -61,7 +61,7 @@
         description: "Multi-Room Music Player"
         icon: mdi-music
         server: pi5-docker
-        container: music-assistant-server
+        container: music-assistant
     - Homebridge:
         href: http://${raspberry_pi_hostname}:8581
         description: "HomeKit Bridge"

--- a/modules/loki-stack/main.tf
+++ b/modules/loki-stack/main.tf
@@ -109,14 +109,16 @@ resource "helm_release" "loki_stack" {
           }
 
           limits_config = {
-            reject_old_samples                    = true
-            reject_old_samples_max_age            = "168h"
-            ingestion_rate_mb                     = 16 # Increased: Alloy ships from 2 machines
-            ingestion_burst_size_mb               = 32
-            max_concurrent_tail_requests          = 20
-            max_outstanding_requests_per_tenant   = 512 # Prevent "too many outstanding requests" with multiple dashboards
-            max_query_parallelism                 = 8
-            retention_period                      = var.loki_retention
+            reject_old_samples           = true
+            reject_old_samples_max_age   = "168h"
+            ingestion_rate_mb            = 16 # Increased: Alloy ships from 2 machines
+            ingestion_burst_size_mb      = 32
+            max_concurrent_tail_requests = 20
+            retention_period             = var.loki_retention
+          }
+
+          frontend = {
+            max_outstanding_per_tenant = 512 # Prevent "too many outstanding requests" with multiple dashboards open
           }
 
           chunk_store_config = {

--- a/modules/loki-stack/main.tf
+++ b/modules/loki-stack/main.tf
@@ -109,12 +109,14 @@ resource "helm_release" "loki_stack" {
           }
 
           limits_config = {
-            reject_old_samples           = true
-            reject_old_samples_max_age   = "168h"
-            ingestion_rate_mb            = 4 # Reduced for Pi 5
-            ingestion_burst_size_mb      = 6
-            max_concurrent_tail_requests = 10
-            retention_period             = var.loki_retention
+            reject_old_samples                    = true
+            reject_old_samples_max_age            = "168h"
+            ingestion_rate_mb                     = 16 # Increased: Alloy ships from 2 machines
+            ingestion_burst_size_mb               = 32
+            max_concurrent_tail_requests          = 20
+            max_outstanding_requests_per_tenant   = 512 # Prevent "too many outstanding requests" with multiple dashboards
+            max_query_parallelism                 = 8
+            retention_period                      = var.loki_retention
           }
 
           chunk_store_config = {

--- a/modules/monitoring-integrations/main.tf
+++ b/modules/monitoring-integrations/main.tf
@@ -120,21 +120,9 @@ resource "kubernetes_config_map" "additional_scrape_configs" {
         scrape_interval = "30s"
         scheme          = "http"
       },
-      # Pi-hole monitoring
-      {
-        job_name = "pi-hole"
-        static_configs = [
-          {
-            targets = ["${var.raspberry_pi_hostname}:${var.pihole_port}"]
-          }
-        ]
-        metrics_path = "/admin/api.php"
-        params = {
-          auth = [var.pihole_api_token]
-        }
-        scrape_interval = "60s"
-      },
-      # Pi-hole Prometheus exporter (port 9617)
+      # Pi-hole Prometheus exporter (port 9617) — Pi-hole v6 compatible
+      # The exporter handles password auth internally via PIHOLE_PASSWORD env var.
+      # Direct /admin/api.php scrape removed: Pi-hole v6 dropped this endpoint.
       {
         job_name = "pihole-exporter"
         static_configs = [

--- a/modules/monitoring-integrations/outputs.tf
+++ b/modules/monitoring-integrations/outputs.tf
@@ -23,6 +23,6 @@ output "monitoring_integrations_summary" {
     external_monitoring = var.enable_external_monitoring
     custom_alerts       = var.enable_custom_alerts
     mac_mini_monitored  = var.mac_mini_ip != ""
-    pihole_monitored    = var.pihole_api_token != ""
+    pihole_monitored    = var.pihole_password != ""
   }
 }

--- a/modules/monitoring-integrations/variables.tf
+++ b/modules/monitoring-integrations/variables.tf
@@ -48,8 +48,8 @@ variable "pihole_port" {
   default     = 8080
 }
 
-variable "pihole_api_token" {
-  description = "Pi-hole API token for metrics scraping"
+variable "pihole_password" {
+  description = "Pi-hole web password for metrics scraping (Pi-hole v6+)"
   type        = string
   default     = ""
   sensitive   = true

--- a/modules/pi-hole/locals.tf
+++ b/modules/pi-hole/locals.tf
@@ -1,0 +1,85 @@
+locals {
+  pihole_exporter_script = <<-PYTHON
+#!/usr/bin/env python3
+"""Pi-hole v6 Prometheus exporter — uses /api/ REST interface (stdlib only)."""
+import json, threading, time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urllib.request import urlopen, Request
+
+PIHOLE_URL = "http://localhost:${var.web_port}"
+PASSWORD   = "${var.pihole_password}"
+PORT       = 9617
+
+_metrics = {}
+_lock    = threading.Lock()
+
+def fetch():
+    try:
+        req = Request(f"{PIHOLE_URL}/api/auth",
+                      data=json.dumps({"password": PASSWORD}).encode(),
+                      headers={"Content-Type": "application/json"}, method="POST")
+        with urlopen(req, timeout=10) as r:
+            sid = json.loads(r.read())["session"]["sid"]
+
+        req = Request(f"{PIHOLE_URL}/api/stats/summary", headers={"X-FTL-SID": sid})
+        with urlopen(req, timeout=10) as r:
+            data = json.loads(r.read())
+
+        Request(f"{PIHOLE_URL}/api/auth", headers={"X-FTL-SID": sid}, method="DELETE")
+        return data
+    except Exception as e:
+        print(f"[pihole-exporter] ERROR: {e}", flush=True)
+        return None
+
+def update_loop():
+    while True:
+        d = fetch()
+        if d:
+            with _lock:
+                _metrics.clear()
+                _metrics.update(d)
+        time.sleep(30)
+
+def render():
+    with _lock:
+        d = dict(_metrics)
+    if not d:
+        return b""
+    lines = []
+    def g(name, help_, val):
+        lines.append(f"# HELP {name} {help_}")
+        lines.append(f"# TYPE {name} gauge")
+        lines.append(f'{name}{{hostname="localhost"}} {val}')
+
+    def v(key, sub=None):
+        x = d.get(key, 0)
+        if isinstance(x, dict): x = x.get(sub or "total", 0)
+        return x
+
+    g("pihole_dns_queries_today",      "Total DNS queries today",          v("queries"))
+    g("pihole_ads_blocked_today",      "Ads/trackers blocked today",       v("blocked"))
+    g("pihole_ads_percentage_today",   "Percentage of queries blocked",    v("percent_blocked"))
+    g("pihole_unique_domains",         "Unique domains seen",              v("unique_domains"))
+    g("pihole_unique_clients",         "Unique clients",                   v("unique_clients"))
+    g("pihole_queries_cached",         "Queries answered from cache",      v("cached"))
+    g("pihole_queries_forwarded",      "Queries forwarded to upstream",    v("forwarded"))
+    g("pihole_domains_being_blocked",  "Domains in gravity blocklist",     d.get("gravity", {}).get("domains_being_blocked", 0))
+    status = 1 if d.get("blocking", "enabled") == "enabled" else 0
+    g("pihole_status", "Blocking status (1=enabled)", status)
+    return ("\n".join(lines) + "\n").encode()
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = render()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a): pass
+
+if __name__ == "__main__":
+    threading.Thread(target=update_loop, daemon=True).start()
+    print(f"[pihole-exporter] Pi-hole v6 exporter on :{PORT}", flush=True)
+    HTTPServer(("", PORT), Handler).serve_forever()
+PYTHON
+}

--- a/modules/pi-hole/main.tf
+++ b/modules/pi-hole/main.tf
@@ -52,7 +52,7 @@ resource "docker_container" "pihole" {
   env = [
     "TZ=${var.timezone}",
     "WEBPASSWORD_FILE=/run/secrets/pihole_password",
-    "DNSMASQ_LISTENING=local"
+    "DNSMASQ_LISTENING=all"
   ]
 
   # Health check
@@ -129,41 +129,64 @@ SCRIPT_EOF
   depends_on = [docker_container.pihole]
 }
 
-resource "docker_image" "pihole_exporter" {
-  name         = "ekofr/pihole-exporter:${var.exporter_version}"
-  keep_locally = true
-}
-
-resource "docker_container" "pihole_exporter" {
-  name  = "pihole-exporter"
-  image = docker_image.pihole_exporter.image_id
-
-  restart = "unless-stopped"
-
-  env = [
-    "PIHOLE_HOSTNAME=localhost",
-    "PIHOLE_PORT=${var.web_port}",
-    "PIHOLE_API_TOKEN=${var.pihole_api_token}",
-    "INTERVAL=30s",
-    "PORT=9617",
-  ]
-
-  network_mode = "host"
-
-  memory = 32
-
-  # Docker sets memory_swap to 2× memory by default; ignore to avoid perpetual diff
-  lifecycle {
-    ignore_changes = [memory_swap]
+# Native Pi-hole v6 Prometheus exporter — deployed as a systemd service.
+# ekofr/pihole-exporter:v0.4.0 uses the removed Pi-hole v5 /admin/api.php endpoint
+# and cannot be used with Pi-hole v6. This minimal Python stdlib exporter uses the
+# v6 /api/ REST interface directly (no Docker Hub pull required).
+resource "null_resource" "pihole_exporter" {
+  triggers = {
+    script_hash = sha256(local.pihole_exporter_script)
+    password    = var.pihole_password
+    hostname    = var.hostname
+    ssh_port    = var.ssh_port
+    ssh_user    = var.ssh_user
   }
 
-  log_opts = var.log_opts
+  # Copy script and install systemd service
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-BASH
+      TMPSCRIPT=$(mktemp /tmp/pihole-exporter-XXXXXX.py)
+      cat > "$TMPSCRIPT" << 'PYEOF'
+${local.pihole_exporter_script}
+PYEOF
+      scp -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -P ${var.ssh_port} "$TMPSCRIPT" ${var.ssh_user}@${var.hostname}:/tmp/pihole_exporter.py
+      rm -f "$TMPSCRIPT"
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${var.ssh_port} ${var.ssh_user}@${var.hostname} bash << 'ENDSSH'
+        sudo cp /tmp/pihole_exporter.py /usr/local/bin/pihole_exporter.py
+        sudo chmod +x /usr/local/bin/pihole_exporter.py
+        sudo tee /etc/systemd/system/pihole-exporter.service > /dev/null << 'SVC'
+[Unit]
+Description=Pi-hole v6 Prometheus Exporter
+After=docker.service
 
-  # pihole-exporter is a scratch-based Go binary — no shell/wget/curl available.
-  # Explicitly disable healthcheck with ["NONE"] so Docker doesn't inherit a
-  # stale wget probe. Health is verified by Prometheus scraping port 9617.
-  healthcheck {
-    test = ["NONE"]
+[Service]
+ExecStart=/usr/bin/python3 /usr/local/bin/pihole_exporter.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+SVC
+        sudo systemctl daemon-reload
+        sudo systemctl enable pihole-exporter
+        sudo systemctl restart pihole-exporter
+        sleep 3
+        sudo systemctl is-active pihole-exporter
+ENDSSH
+    BASH
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-BASH
+      ssh -i ~/.ssh/id_ed25519.rpi5 -o IdentitiesOnly=yes -o StrictHostKeyChecking=no \
+        -p ${self.triggers.ssh_port} ${self.triggers.ssh_user}@${self.triggers.hostname} \
+        "sudo systemctl stop pihole-exporter || true && sudo systemctl disable pihole-exporter || true && sudo rm -f /etc/systemd/system/pihole-exporter.service /usr/local/bin/pihole_exporter.py && sudo systemctl daemon-reload"
+    BASH
   }
 
   depends_on = [docker_container.pihole]
@@ -177,12 +200,10 @@ resource "docker_container" "pihole_exporter" {
 # the rule already exists; deletes gracefully handle missing rules.
 resource "null_resource" "monitoring_firewall_rules" {
   triggers = {
-    container_id = docker_container.pihole_exporter.id
-    # Capture SSH connection vars so the destroy provisioner can use self.triggers
-    # (var.* is not available during destroy; self.triggers always is)
-    hostname  = var.hostname
-    ssh_port  = var.ssh_port
-    ssh_user  = var.ssh_user
+    exporter_id = null_resource.pihole_exporter.id
+    hostname    = var.hostname
+    ssh_port    = var.ssh_port
+    ssh_user    = var.ssh_user
   }
 
   provisioner "local-exec" {
@@ -208,5 +229,5 @@ resource "null_resource" "monitoring_firewall_rules" {
     BASH
   }
 
-  depends_on = [docker_container.pihole_exporter]
+  depends_on = [null_resource.pihole_exporter]
 }

--- a/modules/pi-hole/variables.tf
+++ b/modules/pi-hole/variables.tf
@@ -59,8 +59,8 @@ variable "exporter_version" {
   default     = "v0.4.0"
 }
 
-variable "pihole_api_token" {
-  description = "Pi-hole API token for the exporter to authenticate"
+variable "pihole_password" {
+  description = "Pi-hole web password for the exporter to authenticate (Pi-hole v6+)"
   type        = string
   sensitive   = true
   default     = ""

--- a/modules/prometheus-stack/dashboards/ai-automation.json
+++ b/modules/prometheus-stack/dashboards/ai-automation.json
@@ -155,7 +155,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -252,7 +253,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{container_name=\"homelab-whisper\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -298,7 +300,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -332,7 +335,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     }

--- a/modules/prometheus-stack/dashboards/ai-automation.json
+++ b/modules/prometheus-stack/dashboards/ai-automation.json
@@ -1,0 +1,107 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "title": "n8n Workflows",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "n8n Executions (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))", "legendFormat": "executions", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "n8n Errors (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))", "legendFormat": "errors", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 1},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "n8n Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "id": 5,
+      "title": "Whisper STT",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 8},
+      "id": 6,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Transcription Requests (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homelab-whisper\"} |= \"transcription\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 8},
+      "id": 7,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Whisper Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homelab-whisper\"}", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "id": 8,
+      "title": "Open WebUI & Flowise",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 15},
+      "id": 9,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Open WebUI Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 15},
+      "id": 10,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Flowise Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "analytics", "ai"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "AI & Automation",
+  "uid": "homelab-ai-automation",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ai-automation.json
+++ b/modules/prometheus-stack/dashboards/ai-automation.json
@@ -11,34 +11,34 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
       "id": 2,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "n8n Executions (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))", "legendFormat": "executions", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))", "legendFormat": "executions", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
       "id": 3,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "n8n Errors (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))", "legendFormat": "errors", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))", "legendFormat": "errors", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 12, "x": 12, "y": 1},
       "id": 4,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "n8n Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}", "refId": "A"}]
     },
     {
       "collapsed": false,
@@ -48,24 +48,24 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 8},
       "id": 6,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "Transcription Requests (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homelab-whisper\"} |= \"transcription\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homelab-whisper\"} |= \"transcription\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 18, "x": 6, "y": 8},
       "id": 7,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "Whisper Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homelab-whisper\"}", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homelab-whisper\"}", "refId": "A"}]
     },
     {
       "collapsed": false,
@@ -75,24 +75,24 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 12, "x": 0, "y": 15},
       "id": 9,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "Open WebUI Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 12, "x": 12, "y": 15},
       "id": 10,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "Flowise Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}", "refId": "A"}]
     }
   ],
   "refresh": "5m",

--- a/modules/prometheus-stack/dashboards/ai-automation.json
+++ b/modules/prometheus-stack/dashboards/ai-automation.json
@@ -1,105 +1,356 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 0,
   "panels": [
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "title": "n8n Workflows",
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "n8n Executions (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))", "legendFormat": "executions", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"Execution\" | json [24h]))",
+          "legendFormat": "executions",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 3,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "n8n Errors (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))", "legendFormat": "errors", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({namespace=\"homelab\"} |= \"ERROR\" [24h]))",
+          "legendFormat": "errors",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "id": 4,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "n8n Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{namespace=\"homelab\", pod=~\"n8n.*\"}",
+          "refId": "A"
+        }
+      ]
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 7},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
       "id": 5,
       "title": "Whisper STT",
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 8},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
       "id": 6,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "Transcription Requests (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homelab-whisper\"} |= \"transcription\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homelab-whisper\"} |= \"transcription\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 8},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 8
+      },
       "id": 7,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "Whisper Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homelab-whisper\"}", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{container_name=\"homelab-whisper\"}",
+          "refId": "A"
+        }
+      ]
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 8,
       "title": "Open WebUI & Flowise",
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 15},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "id": 9,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "Open WebUI Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{namespace=\"homelab\", pod=~\"open-webui.*\"}",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 15},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
       "id": 10,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "Flowise Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{namespace=\"homelab\", pod=~\".*flowise.*\"}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "5m",
   "schemaVersion": 38,
-  "tags": ["homelab", "analytics", "ai"],
-  "templating": {"list": []},
-  "time": {"from": "now-24h", "to": "now"},
+  "tags": [
+    "homelab",
+    "analytics",
+    "ai"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timezone": "browser",
   "title": "AI & Automation",
   "uid": "homelab-ai-automation",

--- a/modules/prometheus-stack/dashboards/blackbox-uptime.json
+++ b/modules/prometheus-stack/dashboards/blackbox-uptime.json
@@ -2,160 +2,779 @@
   "id": null,
   "uid": "blackbox-uptime",
   "title": "Network Health (Blackbox Exporter)",
-  "tags": ["homelab", "uptime", "monitoring", "network"],
+  "tags": [
+    "homelab",
+    "uptime",
+    "monitoring",
+    "network"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
-  "time": { "from": "now-24h", "to": "now" },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "refresh": "1m",
   "panels": [
     {
       "id": 1,
       "title": "Router (LAN)",
-      "description": "192.168.0.1 — if this fails, problem is inside the house",
+      "description": "192.168.0.1 \u2014 if this fails, problem is inside the house",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_success{instance=\"192.168.0.1\"}", "instant": true }],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "probe_success{instance=\"192.168.0.1\"}",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            { "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         }
       },
-      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
-      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 }
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      }
     },
     {
       "id": 2,
       "title": "ISP / WAN (1.1.1.1)",
-      "description": "Cloudflare DNS — if router is UP but this is DOWN, problem is ISP",
+      "description": "Cloudflare DNS \u2014 if router is UP but this is DOWN, problem is ISP",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_success{instance=\"1.1.1.1\"}", "instant": true }],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "probe_success{instance=\"1.1.1.1\"}",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            { "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } }, "type": "value" }
+            {
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red"
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green"
+                }
+              },
+              "type": "value"
+            }
           ],
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
         }
       },
-      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
-      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 }
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      }
     },
     {
       "id": 3,
       "title": "Router Latency (now)",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_duration_seconds{instance=\"192.168.0.1\"} * 1000", "instant": true }],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds{instance=\"192.168.0.1\"} * 1000",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 10 }, { "color": "red", "value": 50 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
         }
       },
-      "options": { "colorMode": "value", "graphMode": "none" },
-      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 }
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      }
     },
     {
       "id": 4,
       "title": "ISP Latency (now)",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_duration_seconds{instance=\"1.1.1.1\"} * 1000", "instant": true }],
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ms",
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 50 }, { "color": "red", "value": 150 }] }
-        }
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
       },
-      "options": { "colorMode": "value", "graphMode": "none" },
-      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 }
-    },
-    {
-      "id": 5,
-      "title": "Latency History — Router vs ISP",
-      "description": "Router spike alone = LAN issue. ISP spike with router normal = ISP congestion. Both fail = router/power down.",
-      "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
-        { "expr": "probe_duration_seconds{instance=\"192.168.0.1\", job=\"blackbox-icmp\"} * 1000", "legendFormat": "Router (LAN)" },
-        { "expr": "probe_duration_seconds{instance=\"1.1.1.1\", job=\"blackbox-icmp\"} * 1000", "legendFormat": "ISP (1.1.1.1)" }
+        {
+          "expr": "probe_duration_seconds{instance=\"1.1.1.1\"} * 1000",
+          "instant": true
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "ms",
-          "custom": { "lineWidth": 2, "fillOpacity": 10 },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 100 }, { "color": "red", "value": 200 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 150
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none"
+      },
+      "gridPos": {
+        "x": 18,
+        "y": 0,
+        "w": 6,
+        "h": 4
+      }
+    },
+    {
+      "id": 5,
+      "title": "Latency History \u2014 Router vs ISP",
+      "description": "Router spike alone = LAN issue. ISP spike with router normal = ISP congestion. Both fail = router/power down.",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds{instance=\"192.168.0.1\", job=\"blackbox-icmp\"} * 1000",
+          "legendFormat": "Router (LAN)"
+        },
+        {
+          "expr": "probe_duration_seconds{instance=\"1.1.1.1\", job=\"blackbox-icmp\"} * 1000",
+          "legendFormat": "ISP (1.1.1.1)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 200
+              }
+            ]
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Router (LAN)" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
-          { "matcher": { "id": "byName", "options": "ISP (1.1.1.1)" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Router (LAN)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ISP (1.1.1.1)"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
         ]
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
-      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 9 }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 24,
+        "h": 9
+      }
     },
     {
       "id": 6,
-      "title": "Packet Loss — Router vs ISP",
+      "title": "Packet Loss \u2014 Router vs ISP",
       "description": "% of probes that failed in each 5-minute window. Any loss on router = LAN fault. Loss only on ISP = ISP fault.",
       "type": "timeseries",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        { "expr": "(1 - avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[5m])) * 100", "legendFormat": "Router loss %" },
-        { "expr": "(1 - avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[5m])) * 100", "legendFormat": "ISP loss %" }
+        {
+          "expr": "(1 - avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[5m])) * 100",
+          "legendFormat": "Router loss %"
+        },
+        {
+          "expr": "(1 - avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[5m])) * 100",
+          "legendFormat": "ISP loss %"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
           "min": 0,
           "max": 100,
-          "custom": { "lineWidth": 2, "fillOpacity": 20 },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 5 }, { "color": "red", "value": 20 }] }
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 20
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          }
         },
         "overrides": [
-          { "matcher": { "id": "byName", "options": "Router loss %" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
-          { "matcher": { "id": "byName", "options": "ISP loss %" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Router loss %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "green"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ISP loss %"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "fixed",
+                  "fixedColor": "orange"
+                }
+              }
+            ]
+          }
         ]
       },
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
-      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 8 }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 13,
+        "w": 24,
+        "h": 8
+      }
     },
     {
       "id": 7,
-      "title": "Uptime % — Last 24h",
+      "title": "Uptime % \u2014 Last 24h",
       "type": "stat",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "targets": [
-        { "expr": "avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[24h]) * 100", "legendFormat": "Router" },
-        { "expr": "avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[24h]) * 100", "legendFormat": "ISP" }
+        {
+          "expr": "avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[24h]) * 100",
+          "legendFormat": "Router"
+        },
+        {
+          "expr": "avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[24h]) * 100",
+          "legendFormat": "ISP"
+        }
       ],
       "fieldConfig": {
         "defaults": {
           "unit": "percent",
           "decimals": 2,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 95 }, { "color": "green", "value": 99 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 95
+              },
+              {
+                "color": "green",
+                "value": 99
+              }
+            ]
+          }
         }
       },
-      "options": { "colorMode": "value", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 4 }
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "textMode": "value_and_name",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 21,
+        "w": 12,
+        "h": 4
+      }
     },
     {
       "id": 8,
       "title": "SSL Certificate Expiry",
       "type": "table",
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "(probe_ssl_earliest_cert_expiry - time()) / 86400", "legendFormat": "{{instance}}", "instant": true }],
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "targets": [
+        {
+          "expr": "(probe_ssl_earliest_cert_expiry - time()) / 86400",
+          "legendFormat": "{{instance}}",
+          "instant": true
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "unit": "d",
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 14 }, { "color": "green", "value": 30 }] }
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 14
+              },
+              {
+                "color": "green",
+                "value": 30
+              }
+            ]
+          }
         }
       },
-      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 4 }
+      "gridPos": {
+        "x": 12,
+        "y": 21,
+        "w": 12,
+        "h": 4
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 200,
+      "title": "ISP Bandwidth (Mac Mini \u2014 Wired Ethernet)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 100000000
+              },
+              {
+                "color": "green",
+                "value": 200000000
+              }
+            ]
+          },
+          "unit": "bps",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 26
+      },
+      "id": 201,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "title": "Download (latest)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "speedtest_download_bits_per_second{job=\"speedtest\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 100000000
+              },
+              {
+                "color": "green",
+                "value": 200000000
+              }
+            ]
+          },
+          "unit": "bps",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 26
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "title": "Upload (latest)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "speedtest_upload_bits_per_second{job=\"speedtest\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "ms",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 26
+      },
+      "id": 203,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "title": "Ping (latest)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "speedtest_ping_latency_milliseconds{job=\"speedtest\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bps",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 204,
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "title": "Download / Upload Speed History (30m intervals)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "speedtest_download_bits_per_second{job=\"speedtest\"}",
+          "legendFormat": "Download",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "speedtest_upload_bits_per_second{job=\"speedtest\"}",
+          "legendFormat": "Upload",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "vector(100000000)",
+          "legendFormat": "100 Mbps threshold",
+          "refId": "C"
+        }
+      ]
     }
   ]
 }

--- a/modules/prometheus-stack/dashboards/blackbox-uptime.json
+++ b/modules/prometheus-stack/dashboards/blackbox-uptime.json
@@ -1,48 +1,161 @@
 {
   "id": null,
   "uid": "blackbox-uptime",
-  "title": "Service Uptime (Blackbox Exporter)",
-  "tags": ["homelab", "uptime", "monitoring"],
+  "title": "Network Health (Blackbox Exporter)",
+  "tags": ["homelab", "uptime", "monitoring", "network"],
   "timezone": "browser",
   "schemaVersion": 39,
+  "time": { "from": "now-24h", "to": "now" },
+  "refresh": "1m",
   "panels": [
     {
       "id": 1,
-      "title": "Service Status",
-      "type": "table",
+      "title": "Router (LAN)",
+      "description": "192.168.0.1 — if this fails, problem is inside the house",
+      "type": "stat",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_success", "legendFormat": "{{instance}}", "instant": true }],
+      "targets": [{ "expr": "probe_success{instance=\"192.168.0.1\"}", "instant": true }],
       "fieldConfig": {
         "defaults": {
-          "mappings": [{ "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } }, "type": "value" }]
+          "mappings": [
+            { "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
         }
       },
-      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 }
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "gridPos": { "x": 0, "y": 0, "w": 6, "h": 4 }
     },
     {
       "id": 2,
-      "title": "Probe Duration (ms)",
-      "type": "table",
+      "title": "ISP / WAN (1.1.1.1)",
+      "description": "Cloudflare DNS — if router is UP but this is DOWN, problem is ISP",
+      "type": "stat",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
-      "targets": [{ "expr": "probe_duration_seconds * 1000", "legendFormat": "{{instance}}", "instant": true }],
-      "fieldConfig": { "defaults": { "unit": "ms" } },
-      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 }
+      "targets": [{ "expr": "probe_success{instance=\"1.1.1.1\"}", "instant": true }],
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } }, "type": "value" }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        }
+      },
+      "options": { "colorMode": "background", "graphMode": "none", "textMode": "value" },
+      "gridPos": { "x": 6, "y": 0, "w": 6, "h": 4 }
     },
     {
       "id": 3,
-      "title": "SSL Certificate Expiry (days)",
+      "title": "Router Latency (now)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "probe_duration_seconds{instance=\"192.168.0.1\"} * 1000", "instant": true }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 10 }, { "color": "red", "value": 50 }] }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "none" },
+      "gridPos": { "x": 12, "y": 0, "w": 6, "h": 4 }
+    },
+    {
+      "id": 4,
+      "title": "ISP Latency (now)",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [{ "expr": "probe_duration_seconds{instance=\"1.1.1.1\"} * 1000", "instant": true }],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 50 }, { "color": "red", "value": 150 }] }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "none" },
+      "gridPos": { "x": 18, "y": 0, "w": 6, "h": 4 }
+    },
+    {
+      "id": 5,
+      "title": "Latency History — Router vs ISP",
+      "description": "Router spike alone = LAN issue. ISP spike with router normal = ISP congestion. Both fail = router/power down.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "probe_duration_seconds{instance=\"192.168.0.1\", job=\"blackbox-icmp\"} * 1000", "legendFormat": "Router (LAN)" },
+        { "expr": "probe_duration_seconds{instance=\"1.1.1.1\", job=\"blackbox-icmp\"} * 1000", "legendFormat": "ISP (1.1.1.1)" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 100 }, { "color": "red", "value": 200 }] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Router (LAN)" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+          { "matcher": { "id": "byName", "options": "ISP (1.1.1.1)" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+        ]
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 9 }
+    },
+    {
+      "id": 6,
+      "title": "Packet Loss — Router vs ISP",
+      "description": "% of probes that failed in each 5-minute window. Any loss on router = LAN fault. Loss only on ISP = ISP fault.",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "(1 - avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[5m])) * 100", "legendFormat": "Router loss %" },
+        { "expr": "(1 - avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[5m])) * 100", "legendFormat": "ISP loss %" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "custom": { "lineWidth": 2, "fillOpacity": 20 },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 5 }, { "color": "red", "value": 20 }] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "Router loss %" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }] },
+          { "matcher": { "id": "byName", "options": "ISP loss %" }, "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }] }
+        ]
+      },
+      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } },
+      "gridPos": { "x": 0, "y": 13, "w": 24, "h": 8 }
+    },
+    {
+      "id": 7,
+      "title": "Uptime % — Last 24h",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "avg_over_time(probe_success{instance=\"192.168.0.1\", job=\"blackbox-icmp\"}[24h]) * 100", "legendFormat": "Router" },
+        { "expr": "avg_over_time(probe_success{instance=\"1.1.1.1\", job=\"blackbox-icmp\"}[24h]) * 100", "legendFormat": "ISP" }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 95 }, { "color": "green", "value": 99 }] }
+        }
+      },
+      "options": { "colorMode": "value", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "gridPos": { "x": 0, "y": 21, "w": 12, "h": 4 }
+    },
+    {
+      "id": 8,
+      "title": "SSL Certificate Expiry",
       "type": "table",
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [{ "expr": "(probe_ssl_earliest_cert_expiry - time()) / 86400", "legendFormat": "{{instance}}", "instant": true }],
       "fieldConfig": {
         "defaults": {
           "unit": "d",
-          "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 14 }, { "color": "green", "value": 30 }] }
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 14 }, { "color": "green", "value": 30 }] }
         }
       },
-      "gridPos": { "x": 0, "y": 8, "w": 24, "h": 8 }
+      "gridPos": { "x": 12, "y": 21, "w": 12, "h": 4 }
     }
-  ],
-  "time": { "from": "now-24h", "to": "now" },
-  "refresh": "5m"
+  ]
 }

--- a/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
+++ b/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
@@ -29,25 +29,24 @@
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
       "id": 2,
-      "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
-      },
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_light{entity_id=~\"light\\\\..*\"}",
+        "expr": "homeassistant_switch_state{entity_id=~\"switch\\\\..*kitchen.*|switch\\\\..*light.*\"}",
         "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
+        "instant": true,
         "refId": "A"
       }],
-      "title": "Light Brightness",
-      "type": "timeseries"
+      "title": "Kitchen Switch State",
+      "type": "stat"
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
@@ -63,7 +62,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_binary_sensor{entity_id=~\"binary_sensor\\\\..*occupancy.*|binary_sensor\\\\..*motion.*|binary_sensor\\\\..*presence.*\"}",
+        "expr": "homeassistant_binary_sensor_state",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,

--- a/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
+++ b/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
@@ -1,83 +1,183 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 1,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          }
+        },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_cover{entity_id=~\"cover\\\\..*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_cover{entity_id=~\"cover\\\\..*\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Cover / Curtain Positions",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "id": 2,
-      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_switch_state{entity_id=~\"switch\\\\..*kitchen.*|switch\\\\..*light.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": true,
-        "refId": "A"
-      }],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_switch_state{friendly_name=\"Kitchen Light\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
       "title": "Kitchen Switch State",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          }
+        },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "id": 3,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_binary_sensor_state",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_binary_sensor_state",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Binary Sensors (Presence / Motion)",
       "type": "timeseries"
     }
   ],
   "schemaVersion": 39,
-  "tags": ["homeassistant"],
-  "time": { "from": "now-24h", "to": "now" },
+  "tags": [
+    "homeassistant"
+  ],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Asia/Taipei",
-  "title": "🌅 Daily Rhythm",
+  "title": "\ud83c\udf05 Daily Rhythm",
   "uid": "ha-daily01",
   "version": 1
 }

--- a/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
+++ b/modules/prometheus-stack/dashboards/ha-daily-rhythm.json
@@ -1,0 +1,84 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_cover{entity_id=~\"cover\\\\..*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Cover / Curtain Positions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_light{entity_id=~\"light\\\\..*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Light Brightness",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_binary_sensor{entity_id=~\"binary_sensor\\\\..*occupancy.*|binary_sensor\\\\..*motion.*|binary_sensor\\\\..*presence.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Binary Sensors (Presence / Motion)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["homeassistant"],
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Taipei",
+  "title": "🌅 Daily Rhythm",
+  "uid": "ha-daily01",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ha-home-comfort.json
+++ b/modules/prometheus-stack/dashboards/ha-home-comfort.json
@@ -1,0 +1,84 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor__C{entity_id=~\"sensor\\\\..*temperature.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Temperature Sensors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*humidity.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Humidity Sensors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_lx{entity_id=~\"sensor\\\\..*illuminance.*|sensor\\\\..*light.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Illuminance",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["homeassistant"],
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Taipei",
+  "title": "🏠 Home Comfort",
+  "uid": "ha-comfort1",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ha-home-comfort.json
+++ b/modules/prometheus-stack/dashboards/ha-home-comfort.json
@@ -17,7 +17,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor__C{entity_id=~\"sensor\\\\..*temperature.*\"}",
+        "expr": "homeassistant_sensor_temperature_celsius",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,
@@ -40,7 +40,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*humidity.*\"}",
+        "expr": "homeassistant_sensor_humidity_percent",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,
@@ -63,7 +63,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_lx{entity_id=~\"sensor\\\\..*illuminance.*|sensor\\\\..*light.*\"}",
+        "expr": "homeassistant_sensor_illuminance_lx",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,

--- a/modules/prometheus-stack/dashboards/ha-maintenance-hub.json
+++ b/modules/prometheus-stack/dashboards/ha-maintenance-hub.json
@@ -1,0 +1,116 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "green", "value": 50 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "footer": { "show": false },
+        "showHeader": true,
+        "sortBy": [{ "desc": true, "displayName": "Value" }]
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"}",
+        "format": "table",
+        "instant": true,
+        "legendFormat": "",
+        "refId": "A"
+      }],
+      "title": "All Battery Levels",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "displayMode": "lcd",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "showUnfilled": true
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*brush.*|sensor\\\\..*filter.*|sensor\\\\..*sensor_dirty.*|sensor\\\\..*consumable.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Consumables Health",
+      "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "orange", "value": 1 }, { "color": "red", "value": 3 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 12 },
+      "id": 3,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "count(homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"} < 20)",
+        "legendFormat": "Low Battery Devices",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Low Battery Count (< 20%)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 1 }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 12 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "count(homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"} < 10)",
+        "legendFormat": "Critical Battery Devices",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Critical Battery (< 10%)",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["homeassistant"],
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Taipei",
+  "title": "🔧 Maintenance Hub",
+  "uid": "ha-maint01",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ha-maintenance-hub.json
+++ b/modules/prometheus-stack/dashboards/ha-maintenance-hub.json
@@ -21,7 +21,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"}",
+        "expr": "homeassistant_sensor_battery_percent",
         "format": "table",
         "instant": true,
         "legendFormat": "",
@@ -35,10 +35,8 @@
       "fieldConfig": {
         "defaults": {
           "color": { "mode": "thresholds" },
-          "max": 100,
-          "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
-          "unit": "percent"
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 100 }] },
+          "unit": "h"
         },
         "overrides": []
       },
@@ -52,7 +50,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*brush.*|sensor\\\\..*filter.*|sensor\\\\..*sensor_dirty.*|sensor\\\\..*consumable.*\"}",
+        "expr": "homeassistant_sensor_duration_h",
         "legendFormat": "{{entity_id}}",
         "instant": true,
         "refId": "A"
@@ -74,7 +72,7 @@
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "count(homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"} < 20)",
+        "expr": "count(homeassistant_sensor_battery_percent < 20)",
         "legendFormat": "Low Battery Devices",
         "instant": true,
         "refId": "A"
@@ -96,7 +94,7 @@
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "count(homeassistant_sensor_{entity_id=~\"sensor\\\\..*battery.*\"} < 10)",
+        "expr": "count(homeassistant_sensor_battery_percent < 10)",
         "legendFormat": "Critical Battery Devices",
         "instant": true,
         "refId": "A"

--- a/modules/prometheus-stack/dashboards/ha-network-pulse.json
+++ b/modules/prometheus-stack/dashboards/ha-network-pulse.json
@@ -17,13 +17,13 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*download.*\"}",
+        "expr": "homeassistant_sensor_data_rate_kib_per_s{entity_id=~\".*[Dd]ownload.*\"}",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,
         "refId": "A"
       }],
-      "title": "Download Speed",
+      "title": "Download (KiB/s)",
       "type": "timeseries"
     },
     {
@@ -40,13 +40,13 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*upload.*\"}",
+        "expr": "homeassistant_sensor_data_rate_kib_per_s{entity_id=~\".*[Uu]pload.*\"}",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,
         "refId": "A"
       }],
-      "title": "Upload Speed",
+      "title": "Upload (KiB/s)",
       "type": "timeseries"
     },
     {
@@ -86,7 +86,7 @@
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*download.*\"}",
+        "expr": "homeassistant_sensor_data_rate_kib_per_s{entity_id=~\".*[Dd]ownload.*\"}",
         "legendFormat": "{{entity_id}}",
         "instant": true,
         "refId": "A"
@@ -108,7 +108,7 @@
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*upload.*\"}",
+        "expr": "homeassistant_sensor_data_rate_kib_per_s{entity_id=~\".*[Uu]pload.*\"}",
         "legendFormat": "{{entity_id}}",
         "instant": true,
         "refId": "A"

--- a/modules/prometheus-stack/dashboards/ha-network-pulse.json
+++ b/modules/prometheus-stack/dashboards/ha-network-pulse.json
@@ -1,0 +1,128 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*download.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Download Speed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*upload.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Upload Speed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_ms{entity_id=~\"sensor\\\\..*ping.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Ping Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 4,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*download.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Current Download",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 5,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_Mbit_s{entity_id=~\"sensor\\\\..*upload.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Current Upload",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["homeassistant"],
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Taipei",
+  "title": "📡 Network Pulse",
+  "uid": "ha-net0001",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ha-robot-maid.json
+++ b/modules/prometheus-stack/dashboards/ha-robot-maid.json
@@ -17,7 +17,7 @@
       "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_vacuum{entity_id=~\"vacuum\\\\..*\"}",
+        "expr": "homeassistant_switch_state{entity_id=~\"switch\\\\.roborock.*\"}",
         "legendFormat": "{{entity_id}}",
         "instant": true,
         "refId": "A"
@@ -39,7 +39,7 @@
       },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_m_{entity_id=~\"sensor\\\\..*cleaning_area.*|sensor\\\\..*area.*\"}",
+        "expr": "homeassistant_sensor_unit_mu0xb2",
         "legendFormat": "{{entity_id}}",
         "instant": false,
         "range": true,
@@ -52,101 +52,109 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "max": 100,
-          "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
-          "unit": "percent"
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "h"
         },
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
       "id": 3,
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*main_brush.*\"}",
+        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*main_brush.*\"}",
         "legendFormat": "{{entity_id}}",
-        "instant": true,
+        "instant": false,
+        "range": true,
         "refId": "A"
       }],
       "title": "Main Brush Life Remaining",
-      "type": "gauge"
+      "type": "timeseries"
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "max": 100,
-          "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
-          "unit": "percent"
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "h"
         },
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
       "id": 4,
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*side_brush.*\"}",
+        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*filter.*\"}",
         "legendFormat": "{{entity_id}}",
-        "instant": true,
+        "instant": false,
+        "range": true,
         "refId": "A"
       }],
-      "title": "Side Brush Life",
-      "type": "gauge"
+      "title": "Filter Life",
+      "type": "timeseries"
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "max": 100,
-          "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
-          "unit": "percent"
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "h"
         },
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
       "id": 5,
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*filter.*\"}",
+        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*dock_strainer.*|.*strainer.*\"}",
         "legendFormat": "{{entity_id}}",
-        "instant": true,
+        "instant": false,
+        "range": true,
         "refId": "A"
       }],
-      "title": "Filter Life",
-      "type": "gauge"
+      "title": "Dock Strainer Life",
+      "type": "timeseries"
     },
     {
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "max": 100,
-          "min": 0,
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
-          "unit": "percent"
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 1 },
+          "unit": "h"
         },
         "overrides": []
       },
       "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
       "id": 6,
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [{
         "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*sensor_dirty.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": true,
+        "expr": "homeassistant_sensor_duration_min",
+        "legendFormat": "Cleaning time (min)",
+        "instant": false,
+        "range": true,
         "refId": "A"
       }],
-      "title": "Sensor Dirty Remaining",
-      "type": "gauge"
+      "title": "Cleaning Time",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 39,

--- a/modules/prometheus-stack/dashboards/ha-robot-maid.json
+++ b/modules/prometheus-stack/dashboards/ha-robot-maid.json
@@ -1,168 +1,349 @@
 {
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 1,
   "panels": [
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_switch_state{entity_id=~\"switch\\\\.roborock.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": true,
-        "refId": "A"
-      }],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_state{entity=\"sensor.roborock_state_numeric\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
       "title": "Current Vacuum State",
       "type": "stat"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          }
+        },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
       "id": 2,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_unit_mu0xb2",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_unit_mu0xb2",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Cleaning Area Over Time",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 1 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          },
           "unit": "h"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
       "id": 3,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*main_brush.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_duration_h{entity=~\".*main_brush.*\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Main Brush Life Remaining",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 1 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          },
           "unit": "h"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 8
+      },
       "id": 4,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*filter.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_duration_h{entity=~\".*filter.*\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Filter Life",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 1 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          },
           "unit": "h"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 8
+      },
       "id": 5,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_duration_h{entity_id=~\".*dock_strainer.*|.*strainer.*\"}",
-        "legendFormat": "{{entity_id}}",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_duration_h{entity=~\".*dock_strainer.*|.*side_brush.*|.*sensor_time.*\"}",
+          "legendFormat": "{{entity_id}}",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Dock Strainer Life",
       "type": "timeseries"
     },
     {
-      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "palette-classic" },
-          "custom": { "lineWidth": 1 },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "lineWidth": 1
+          },
           "unit": "h"
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 8
+      },
       "id": 6,
       "options": {
-        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
-        "tooltip": { "mode": "multi", "sort": "desc" }
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "targets": [{
-        "datasource": { "type": "prometheus", "uid": "prometheus" },
-        "expr": "homeassistant_sensor_duration_min",
-        "legendFormat": "Cleaning time (min)",
-        "instant": false,
-        "range": true,
-        "refId": "A"
-      }],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "homeassistant_sensor_duration_min",
+          "legendFormat": "Cleaning time (min)",
+          "instant": false,
+          "range": true,
+          "refId": "A"
+        }
+      ],
       "title": "Cleaning Time",
       "type": "timeseries"
     }
   ],
   "schemaVersion": 39,
-  "tags": ["homeassistant"],
-  "time": { "from": "now-24h", "to": "now" },
+  "tags": [
+    "homeassistant"
+  ],
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Asia/Taipei",
-  "title": "🤖 Robot Maid",
+  "title": "\ud83e\udd16 Robot Maid",
   "uid": "ha-robot01",
   "version": 1
 }

--- a/modules/prometheus-stack/dashboards/ha-robot-maid.json
+++ b/modules/prometheus-stack/dashboards/ha-robot-maid.json
@@ -1,0 +1,160 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_vacuum{entity_id=~\"vacuum\\\\..*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Current Vacuum State",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 1 } },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 18, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["lastNotNull", "max", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_m_{entity_id=~\"sensor\\\\..*cleaning_area.*|sensor\\\\..*area.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": false,
+        "range": true,
+        "refId": "A"
+      }],
+      "title": "Cleaning Area Over Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*main_brush.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Main Brush Life Remaining",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 6, "y": 8 },
+      "id": 4,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*side_brush.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Side Brush Life",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "id": 5,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*filter.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Filter Life",
+      "type": "gauge"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "max": 100,
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 20 }, { "color": "yellow", "value": 50 }, { "color": "green", "value": 80 }] },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "id": 6,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [{
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "expr": "homeassistant_sensor_{entity_id=~\"sensor\\\\..*sensor_dirty.*\"}",
+        "legendFormat": "{{entity_id}}",
+        "instant": true,
+        "refId": "A"
+      }],
+      "title": "Sensor Dirty Remaining",
+      "type": "gauge"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["homeassistant"],
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Taipei",
+  "title": "🤖 Robot Maid",
+  "uid": "ha-robot01",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/ha-security.json
+++ b/modules/prometheus-stack/dashboards/ha-security.json
@@ -4,44 +4,44 @@
   "graphTooltip": 0,
   "panels": [
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 5}, {"color": "red", "value": 20}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
       "id": 1,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "Failed Login Attempts (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
       "id": 2,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "Banned IPs (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ban\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ban\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"custom": {"fillOpacity": 10}, "color": {"mode": "palette-classic"}}},
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
       "id": 3,
       "options": {"tooltip": {"mode": "single"}},
       "title": "Failed Login Attempts Over Time",
       "type": "timeseries",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))", "legendFormat": "failed logins", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))", "legendFormat": "failed logins", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
       "id": 4,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "HA Authentication Log (failed attempts)",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"", "refId": "A"}]
     }
   ],
   "refresh": "5m",

--- a/modules/prometheus-stack/dashboards/ha-security.json
+++ b/modules/prometheus-stack/dashboards/ha-security.json
@@ -1,54 +1,213 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 0,
   "panels": [
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 5}, {"color": "red", "value": 20}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "Failed Login Attempts (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
       "id": 2,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "Banned IPs (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ban\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ban\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"custom": {"fillOpacity": 10}, "color": {"mode": "palette-classic"}}},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "fillOpacity": 10
+          },
+          "color": {
+            "mode": "palette-classic"
+          }
+        }
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "id": 3,
-      "options": {"tooltip": {"mode": "single"}},
+      "options": {
+        "tooltip": {
+          "mode": "single"
+        }
+      },
       "title": "Failed Login Attempts Over Time",
       "type": "timeseries",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))", "legendFormat": "failed logins", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))",
+          "legendFormat": "failed logins",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
       "id": 4,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "HA Authentication Log (failed attempts)",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "5m",
   "schemaVersion": 38,
-  "tags": ["homelab", "security"],
-  "templating": {"list": []},
-  "time": {"from": "now-24h", "to": "now"},
+  "tags": [
+    "homelab",
+    "security"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timezone": "browser",
   "title": "HA Security",
   "uid": "homelab-ha-security",

--- a/modules/prometheus-stack/dashboards/ha-security.json
+++ b/modules/prometheus-stack/dashboards/ha-security.json
@@ -156,7 +156,8 @@
           },
           "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))",
           "legendFormat": "failed logins",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -190,7 +191,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     }

--- a/modules/prometheus-stack/dashboards/ha-security.json
+++ b/modules/prometheus-stack/dashboards/ha-security.json
@@ -1,0 +1,56 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 5}, {"color": "red", "value": 20}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Failed Login Attempts (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Banned IPs (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ban\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"custom": {"fillOpacity": 10}, "color": {"mode": "palette-classic"}}},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 3,
+      "options": {"tooltip": {"mode": "single"}},
+      "title": "Failed Login Attempts Over Time",
+      "type": "timeseries",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"invalid authentication\" [5m]))", "legendFormat": "failed logins", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 8},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "HA Authentication Log (failed attempts)",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} |= \"invalid authentication\"", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "security"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "HA Security",
+  "uid": "homelab-ha-security",
+  "version": 1
+}

--- a/modules/prometheus-stack/dashboards/home-music.json
+++ b/modules/prometheus-stack/dashboards/home-music.json
@@ -1,88 +1,308 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": []
+  },
   "editable": true,
   "graphTooltip": 0,
   "panels": [
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "id": 1,
       "title": "Home Assistant",
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "id": 2,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "Automations Fired (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"Executing script\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"Executing script\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "id": 3,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "HA Errors (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ERROR\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ERROR\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
       "id": 4,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "HA Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} | level != \"debug\"", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{container_name=\"homeassistant\"}",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
       "id": 5,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "Google Home Commands",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"",
+          "refId": "A"
+        }
+      ]
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11},
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
       "id": 6,
       "title": "Music Assistant",
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 12},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 12
+      },
       "id": 7,
-      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "sum"
+          ]
+        }
+      },
       "title": "Tracks Played (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"music-assistant-server\"} |= \"Playing\" [24h]))", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({container_name=\"music-assistant\"} |= \"Playing\" [24h]))",
+          "refId": "A"
+        }
+      ]
     },
     {
-      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
-      "fieldConfig": {"defaults": {}},
-      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 12},
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 12
+      },
       "id": 8,
-      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "showTime": true,
+        "sortOrder": "Descending"
+      },
       "title": "Music Assistant Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"music-assistant-server\"}", "refId": "A"}]
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{container_name=\"music-assistant\"}",
+          "refId": "A"
+        }
+      ]
     }
   ],
   "refresh": "5m",
   "schemaVersion": 38,
-  "tags": ["homelab", "analytics", "home"],
-  "templating": {"list": []},
-  "time": {"from": "now-24h", "to": "now"},
+  "tags": [
+    "homelab",
+    "analytics",
+    "home"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
   "timezone": "browser",
   "title": "Home & Music",
   "uid": "homelab-home-music",

--- a/modules/prometheus-stack/dashboards/home-music.json
+++ b/modules/prometheus-stack/dashboards/home-music.json
@@ -153,7 +153,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{container_name=\"homeassistant\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -187,7 +188,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     },
@@ -284,7 +286,8 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "expr": "{container_name=\"music-assistant\"}",
-          "refId": "A"
+          "refId": "A",
+          "queryType": "range"
         }
       ]
     }

--- a/modules/prometheus-stack/dashboards/home-music.json
+++ b/modules/prometheus-stack/dashboards/home-music.json
@@ -11,44 +11,44 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
       "id": 2,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "Automations Fired (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"Executing script\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"Executing script\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
       "id": 3,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "HA Errors (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ERROR\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ERROR\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
       "id": 4,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "HA Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} | level != \"debug\"", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} | level != \"debug\"", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
       "id": 5,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "Google Home Commands",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"", "refId": "A"}]
     },
     {
       "collapsed": false,
@@ -58,24 +58,24 @@
       "type": "row"
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 12},
       "id": 7,
       "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
       "title": "Tracks Played (24h)",
       "type": "stat",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"music-assistant-server\"} |= \"Playing\" [24h]))", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "sum(count_over_time({container_name=\"music-assistant-server\"} |= \"Playing\" [24h]))", "refId": "A"}]
     },
     {
-      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"},
       "fieldConfig": {"defaults": {}},
       "gridPos": {"h": 6, "w": 18, "x": 6, "y": 12},
       "id": 8,
       "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
       "title": "Music Assistant Recent Logs",
       "type": "logs",
-      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"music-assistant-server\"}", "refId": "A"}]
+      "targets": [{"datasource": {"type": "loki", "uid": "P8E80F9AEF21F6940"}, "expr": "{container_name=\"music-assistant-server\"}", "refId": "A"}]
     }
   ],
   "refresh": "5m",

--- a/modules/prometheus-stack/dashboards/home-music.json
+++ b/modules/prometheus-stack/dashboards/home-music.json
@@ -1,0 +1,90 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "graphTooltip": 0,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 1,
+      "title": "Home Assistant",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Automations Fired (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"Executing script\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "HA Errors (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"homeassistant\"} |= \"ERROR\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 1},
+      "id": 4,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "HA Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} | level != \"debug\"", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
+      "id": 5,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Google Home Commands",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"homeassistant\"} |= \"google_assistant\"", "refId": "A"}]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11},
+      "id": 6,
+      "title": "Music Assistant",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"steps": [{"color": "green", "value": null}]}}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 12},
+      "id": 7,
+      "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["sum"]}},
+      "title": "Tracks Played (24h)",
+      "type": "stat",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "sum(count_over_time({container_name=\"music-assistant-server\"} |= \"Playing\" [24h]))", "refId": "A"}]
+    },
+    {
+      "datasource": {"type": "loki", "uid": "${loki_uid}"},
+      "fieldConfig": {"defaults": {}},
+      "gridPos": {"h": 6, "w": 18, "x": 6, "y": 12},
+      "id": 8,
+      "options": {"dedupStrategy": "none", "enableLogDetails": true, "showTime": true, "sortOrder": "Descending"},
+      "title": "Music Assistant Recent Logs",
+      "type": "logs",
+      "targets": [{"datasource": {"type": "loki", "uid": "${loki_uid}"}, "expr": "{container_name=\"music-assistant-server\"}", "refId": "A"}]
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 38,
+  "tags": ["homelab", "analytics", "home"],
+  "templating": {"list": []},
+  "time": {"from": "now-24h", "to": "now"},
+  "timezone": "browser",
+  "title": "Home & Music",
+  "uid": "homelab-home-music",
+  "version": 1
+}

--- a/modules/prometheus-stack/main.tf
+++ b/modules/prometheus-stack/main.tf
@@ -180,6 +180,8 @@ resource "helm_release" "prometheus_stack" {
       # Prometheus configuration
       prometheus = {
         prometheusSpec = {
+          enableRemoteWriteReceiver = true
+
           # Add pod labels for Homepage integration
           podMetadata = {
             labels = {

--- a/modules/prometheus-stack/main.tf
+++ b/modules/prometheus-stack/main.tf
@@ -145,6 +145,15 @@ locals {
       metrics_path    = "/metrics"
       scrape_interval = "30s"
     },
+    # Speedtest exporter on Mac Mini — runs every 30 min to verify ISP bandwidth
+    # Uses wired Ethernet for accurate results. Metrics: download/upload Mbps, ping ms.
+    {
+      job_name        = "speedtest"
+      static_configs  = [{ targets = ["${var.mac_mini_ip}:9798"], labels = { instance = "mac-mini", service = "speedtest" } }]
+      metrics_path    = "/metrics"
+      scrape_interval = "30m" # Don't run too frequently — each test uses ~200MB of bandwidth
+      scrape_timeout  = "90s" # Speedtest takes up to 60s to complete
+    },
     # CrowdSec IDS metrics (community bans + local decisions)
     {
       job_name       = "crowdsec"

--- a/modules/prometheus-stack/main.tf
+++ b/modules/prometheus-stack/main.tf
@@ -119,6 +119,61 @@ resource "kubernetes_config_map" "grafana_dashboard_ha_security" {
   }
 }
 
+resource "kubernetes_config_map" "grafana_dashboard_ha_home_comfort" {
+  metadata {
+    name      = "grafana-ha-home-comfort"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-home-comfort.json" = file("${path.module}/dashboards/ha-home-comfort.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_ha_robot_maid" {
+  metadata {
+    name      = "grafana-ha-robot-maid"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-robot-maid.json" = file("${path.module}/dashboards/ha-robot-maid.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_ha_network_pulse" {
+  metadata {
+    name      = "grafana-ha-network-pulse"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-network-pulse.json" = file("${path.module}/dashboards/ha-network-pulse.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_ha_daily_rhythm" {
+  metadata {
+    name      = "grafana-ha-daily-rhythm"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-daily-rhythm.json" = file("${path.module}/dashboards/ha-daily-rhythm.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_ha_maintenance_hub" {
+  metadata {
+    name      = "grafana-ha-maintenance-hub"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-maintenance-hub.json" = file("${path.module}/dashboards/ha-maintenance-hub.json")
+  }
+}
+
 # Build the list of additional scrape job configs.
 # All scrape targets use raw IPs — K3s CoreDNS cannot resolve .local mDNS hostnames.
 locals {

--- a/modules/prometheus-stack/main.tf
+++ b/modules/prometheus-stack/main.tf
@@ -86,6 +86,39 @@ resource "kubernetes_config_map" "grafana_dashboard_resource_comparison" {
   }
 }
 
+resource "kubernetes_config_map" "grafana_dashboard_ai_automation" {
+  metadata {
+    name      = "grafana-ai-automation"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ai-automation.json" = file("${path.module}/dashboards/ai-automation.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_home_music" {
+  metadata {
+    name      = "grafana-home-music"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "home-music.json" = file("${path.module}/dashboards/home-music.json")
+  }
+}
+
+resource "kubernetes_config_map" "grafana_dashboard_ha_security" {
+  metadata {
+    name      = "grafana-ha-security"
+    namespace = var.namespace
+    labels    = { grafana_dashboard = "1" }
+  }
+  data = {
+    "ha-security.json" = file("${path.module}/dashboards/ha-security.json")
+  }
+}
+
 # Build the list of additional scrape job configs.
 # All scrape targets use raw IPs — K3s CoreDNS cannot resolve .local mDNS hostnames.
 locals {

--- a/modules/prometheus-stack/variables.tf
+++ b/modules/prometheus-stack/variables.tf
@@ -226,10 +226,19 @@ variable "blackbox_http_targets" {
   description = "HTTP/HTTPS endpoints for Blackbox Exporter to probe"
   type        = list(string)
   default = [
+    # Core AI / productivity
     "https://open-webui.rainforest.tools",
     "https://n8n.rainforest.tools",
+    "https://flowise.rainforest.tools",
+    # Media / books
     "https://calibre-web.rainforest.tools",
+    # IoT / home
+    "https://homeassistant.rainforest.tools",
+    "https://bambii.rainforest.tools",
+    # Infrastructure
     "https://whisper.rainforest.tools",
+    "https://minio.rainforest.tools",
+    "https://pgadmin.rainforest.tools",
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -153,6 +153,13 @@ variable "grafana_admin_password" {
   sensitive   = true
 }
 
+variable "homeassistant_token" {
+  description = "Home Assistant long-lived access token for Prometheus scraping via /api/prometheus"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 # Additional K8s configuration variables (added to existing K8s section above)
 variable "k8s_enable_monitoring" {
   description = "Enable monitoring namespace and features"

--- a/variables.tf
+++ b/variables.tf
@@ -323,8 +323,8 @@ variable "mac_mini_docker_endpoint" {
   default     = "dockerproxy.orb.local:2375"
 }
 
-variable "pihole_api_token" {
-  description = "Pi-hole API token for metrics"
+variable "pihole_password" {
+  description = "Pi-hole web password for metrics exporter (Pi-hole v6+)"
   type        = string
   default     = ""
   sensitive   = true

--- a/variables.tf
+++ b/variables.tf
@@ -540,3 +540,9 @@ variable "minio_secret_key" {
   type        = string
   sensitive   = true
 }
+
+variable "alloy_pi_version" {
+  description = "Grafana Alloy version for Pi deployment"
+  type        = string
+  default     = "v1.8.2"
+}


### PR DESCRIPTION
## Summary

- **Enable HA Prometheus endpoint** — injects `prometheus:` block into HA `configuration.yaml` via SSH + `docker exec`, idempotent
- **HA Prometheus scrape job** — adds token-authenticated scrape job in the `prometheus-stack` module pointing at `http://192.168.0.128:8123/api/prometheus`
- **5 Grafana dashboards** as Kubernetes ConfigMaps (auto-imported via Grafana sidecar):
  - 🏠 **Home Comfort** (`ha-comfort1`) — temperature, humidity, illuminance from Hub 2 (Aqara)
  - 🤖 **Robot Maid** (`ha-robot01`) — vacuum state, cleaning area, consumable hours remaining (Roborock Qrevo C Pro)
  - 📡 **Network Pulse** (`ha-net0001`) — download/upload KiB/s from SCR 50AXE router
  - 🌅 **Daily Rhythm** (`ha-daily01`) — cover positions (2 SwitchBot curtains), Kitchen Light switch state, binary sensors
  - 🔧 **Maintenance Hub** (`ha-maint01`) — battery levels for 7 devices, Roborock consumable time remaining

## Key technical decisions

**HA 2024 metric naming** — HA 2024.x changed Prometheus metric names from special-char sanitization to descriptive names:
- `homeassistant_sensor__C` → `homeassistant_sensor_temperature_celsius`
- `homeassistant_sensor_lx` → `homeassistant_sensor_illuminance_lx`
- `homeassistant_sensor_m_` → `homeassistant_sensor_unit_mu0xb2`
- `homeassistant_sensor_Mbit_s` → `homeassistant_sensor_data_rate_kib_per_s`

**Vacuum state template sensor** — HA's Prometheus integration skips the `vacuum` domain because its state is a string. Added a `null_resource.ha_vacuum_template_sensor` that injects a HA template sensor mapping vacuum state → numeric (0=unknown, 1=cleaning, 2=returning, 3=docked, 4=paused, 5=idle, 6=error). Queried as `homeassistant_sensor_state{entity="sensor.roborock_state_numeric"}`.

**Kitchen Light entity ID** — SwitchBot Bot has opaque entity ID `switch.bot_1a51`. Dashboard uses `friendly_name="Kitchen Light"` Prometheus label filter for stability.

**Entity label naming** — HA Prometheus uses `entity` label (not `entity_id`). All selector queries corrected.

## Missing integrations (optional future additions)

- **Speedtest.net** — router currently exports KiB/s; add HA Speedtest integration for Mbit/s + ping
- **Vacuum domain** — Roborock state is available via template sensor; no HA change needed

## Test plan

- [x] HA Prometheus endpoint returns HTTP 200: `curl http://192.168.0.128:8123/api/prometheus`
- [x] `sensor.roborock_state_numeric` in HA with state `3` (docked)
- [x] `homeassistant_sensor_state{entity="sensor.roborock_state_numeric"}` in Prometheus
- [x] `homeassistant_sensor_temperature_celsius` returning 28.7°C
- [x] All 5 dashboard ConfigMaps deployed to `monitoring` namespace
- [x] Grafana sidecar auto-imported all dashboards (verified at `http://192.168.0.128:30080`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)