### PR TITLE
fix(monitoring): stop probing the retired Obsidian MCP endpoint

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -554,7 +554,9 @@ variable "blackbox_mcp_targets" {
   type        = list(string)
   default = [
     "https://docker-mcp.rainforest.tools",
-    "https://obsidian.rainforest.tools",
+    # obsidian.rainforest.tools retired 2026-07-29 — the standalone Obsidian MCP
+    # server was folded into the Docker MCP gateway, so probing it only produced a
+    # permanently-failing alert.
     "https://calibre-mcp.rainforest.tools",
   ]
 }


### PR DESCRIPTION
## Summary

`obsidian.rainforest.tools` was retired when the standalone Obsidian MCP server was folded into the Docker MCP gateway, but it was still in the blackbox probe target list. The probe therefore failed permanently, and the incident-log workflow dutifully wrote the resulting `BlackboxProbeFailed` alert into the Obsidian daily note.

Removes the target and records why, so it is not re-added by reflex.

## Not applied yet

The Raspberry Pi hosting Prometheus is currently offline, so `terraform apply` could not run. The change takes effect on the next apply once the Pi is back.

## Verification

`terraform validate` passes. The remaining probe targets (`docker-mcp`, `calibre-mcp`) are both live services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)