### PR TITLE
feat(homepage): list the eight services that were only reachable by URL

### DIFF
--- a/modules/homepage/templates/services.yaml.tpl
+++ b/modules/homepage/templates/services.yaml.tpl
@@ -15,6 +15,16 @@
         icon: mdi-microphone-message
         server: macmini-docker
         container: homelab-whisper
+    - ComfyUI:
+        href: https://comfyui.rainforest.tools/
+        description: "Node-Based Image Generation Workflows"
+        icon: comfyui.png
+        # Runs natively on the mini via uv, not in Docker — no container to poll
+    - Antigravity:
+        href: https://agy.rainforest.tools/
+        description: "Multi-Model AI CLI (Gemini / Claude / GPT-OSS)"
+        icon: mdi-robot
+        # Runs natively on the mini — no container to poll
 
 - "Mac Mini M4 (Storage & Files)":
     - MinIO Console:
@@ -33,21 +43,50 @@
         icon: calibre-web.png
         server: macmini-docker
         container: homelab-calibre-web
-
-- "Mac Mini M4 (Database & Admin)":
-    - pgAdmin:
-        href: https://pgadmin.rainforest.tools/
-        description: "PostgreSQL Database Admin"
-        icon: pgadmin.png
-        # K8s-managed: container name changes on every pod restart, omitted to avoid stale "not found"
+    - Calibre:
+        href: https://calibre.rainforest.tools/
+        description: "Calibre Content Server (library backend)"
+        icon: calibre.png
+        server: macmini-docker
+        container: homelab-personal-calibre
 
 - "Mac Mini M4 (Development Tools)":
     - Docker MCP Gateway:
         href: https://docker-mcp.rainforest.tools/
         description: "Claude Code Integration"
         icon: docker.png
+        # launchd service on the mini (`docker mcp gateway run`, PORT=3101), not Docker —
+        # the old homelab-docker-mcp-gateway container is gone and polling it showed
+        # a permanent "not found".
+    - Teleport:
+        href: https://tp.rainforest.tools/
+        description: "Secure SSH & Kubernetes Access"
+        icon: teleport.png
+        # K8s-managed: container name changes on every pod restart, omitted to avoid stale "not found"
+    - Loop Observatory:
+        href: https://loop.rainforest.tools/
+        description: "Autonomous Task Loop Dashboard"
+        icon: mdi-autorenew
+        # launchd service on the mini (PORT=3099), not Docker — no container to poll
+
+- "Mac Mini M4 (Personal Dashboards)":
+    - Finance Audit:
+        href: https://finance.rainforest.tools/
+        description: "Credit Card Reconciliation & Rewards Audit"
+        icon: mdi-credit-card-check-outline
         server: macmini-docker
-        container: homelab-docker-mcp-gateway
+        container: homelab-finance-audit
+    - RSS Manager:
+        href: https://rss.rainforest.tools/
+        description: "Feed Subscription Manager"
+        icon: mdi-rss
+        server: macmini-docker
+        container: homelab-rss-manager
+    - Bambii Focus:
+        href: https://bambii.rainforest.tools/
+        description: "Pomodoro Focus Timer"
+        icon: mdi-timer-outline
+        # Runs natively on the mini — no container to poll
 
 - "Raspberry Pi 5 (IoT Platform)":
     - HomeAssistant:
@@ -83,7 +122,10 @@
 
 - "Monitoring & Observability (K3s on Pi 5)":
     - Grafana:
-        href: http://${raspberry_pi_hostname}:${grafana_port}
+        # href is the public Zero Trust route so the link works off the LAN;
+        # the widget below must stay on the LAN IP — that call is made by the
+        # homepage container itself and would fail against the Access-gated host.
+        href: https://gfn.rainforest.tools/
         description: "Dashboards & Visualization"
         icon: grafana.png
         namespace: monitoring


### PR DESCRIPTION
Eight services had a public hostname and a Zero Trust policy in `rainforest-homelab` but no tile here, so the only way to reach them was typing the URL from memory.

## Added

| Service | Host | Group |
|---|---|---|
| ComfyUI | `comfyui` | AI & Automation |
| Antigravity | `agy` | AI & Automation |
| Calibre | `calibre` | Storage & Files |
| Teleport | `tp` | Development Tools |
| Loop Observatory | `loop` | Development Tools |
| Finance Audit | `finance` | Personal Dashboards *(new group)* |
| RSS Manager | `rss` | Personal Dashboards |
| Bambii Focus | `bambii` | Personal Dashboards |

Grouped by where a service runs rather than what it is, matching the existing sections. The three that are neither infra nor AI tooling get their own group.

## Fixed — three tiles were lying about state

- **pgAdmin linked nowhere.** It was dropped from the homelab config as never-deployed (`enable_pgadmin = false`), so the tile pointed at a service that does not exist. Its group had no other member and goes with it.
- **Grafana's `href` was a LAN address**, which fails off the LAN. `gfn.rainforest.tools` is the same instance (`grafana_port` defaults to 30080) and is Access-gated. The `widget.url` deliberately stays on the LAN IP — that call is made by the homepage container itself, which cannot satisfy Access.
- **Docker MCP Gateway polled a container that no longer exists.** `homelab-docker-mcp-gateway` is gone; the gateway is a launchd service on `:3101`. Polling it showed a permanent "not found".

## Verification

Applied and read back from the running instance, not from the template:

```
GET /api/services (Host: homepage.rainforest.tools) → 200
```

- All 8 new services present, 23 total across 6 groups
- pgAdmin absent
- Control assertion included (`Open WebUI` must be present) so a failed fetch cannot masquerade as a passing check — this caught an earlier verification attempt that was reading the HTML shell, which never contains service names because the list is client-rendered
- Rendered YAML parses; every template variable used is supplied by `local.template_vars`
- Every icon checked against the CDN first: `rss.png` and `antigravity.png` do not exist in dashboard-icons, so those two use mdi icons
- `macmini-docker` (`:2375`) reachable, so the three new `container:` status badges resolve

## Note

Branched from `origin/main` rather than the currently checked-out `fix/retire-obsidian-blackbox-probe`, which is a separate, already-pushed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)